### PR TITLE
Files can now be deleted

### DIFF
--- a/config/routes.php
+++ b/config/routes.php
@@ -41,6 +41,7 @@ return [
   [ 'POST','/sketch/[:sketchId]/save', 'SketchSaveController', 'sketchSave' ],
   [ 'POST','/sketch/[:sketchId]/rename', 'SketchRenameController', 'sketchRename' ],
   [ 'POST','/sketch/[:sketchId]/addFile', 'SketchAddFileController', 'sketchAddFile' ],
+  [ 'POST','/sketch/[:sketchId]/deleteFile', 'SketchDeleteFileController', 'sketchDeleteFile' ],
   [ 'POST','/upload/asset', 'UploadAssetController', 'uploadAsset' ],
   [ 'GET','/categories/[:slug]', 'CategoriesShowController', 'categoriesShow' ],
   [ 'GET','/categories/[:slug]/sort', 'CategoriesSortController', 'categoriesSort' ],

--- a/config/services.php
+++ b/config/services.php
@@ -669,6 +669,16 @@ $di->set('SketchAddFileController', function () use ($di) {
   );
 });
 
+$di->set('SketchDeleteFileController', function () use ($di) {
+  return new Pyangelo\Controllers\Sketch\SketchDeleteFileController (
+    $di->get('request'),
+    $di->get('response'),
+    $di->get('auth'),
+    $di->get('sketchRepository'),
+    $di->get('sketchFiles')
+  );
+});
+
 $di->set('UploadAssetController', function () use ($di) {
   return new PyAngelo\Controllers\Upload\UploadAssetController (
     $di->get('request'),

--- a/config/services.php
+++ b/config/services.php
@@ -670,7 +670,7 @@ $di->set('SketchAddFileController', function () use ($di) {
 });
 
 $di->set('SketchDeleteFileController', function () use ($di) {
-  return new Pyangelo\Controllers\Sketch\SketchDeleteFileController (
+  return new PyAngelo\Controllers\Sketch\SketchDeleteFileController (
     $di->get('request'),
     $di->get('response'),
     $di->get('auth'),

--- a/resources/assets/js/editor.js
+++ b/resources/assets/js/editor.js
@@ -492,19 +492,19 @@ function deleteFile(filename) {
   };
   fetch('/sketch/' + sketchId + '/deleteFile', options)
   .then(response => {
-		if(response.status < 200 || response.status > 299) {
-			throw response;
-		}
-		return response.json();
-	})
-	.then(deleteOldFile)
+    if(response.status < 200 || response.status > 299) {
+      throw response;
+    }
+    return response.json();
+  })
+  .then(deleteOldFile)
   .catch(error => { console.log('Error: ', error); })
 }
 function deleteOldFile(response) {
   let span = document.querySelector(`.editorTab[data-filename='${response.filename}']`);
   if(!span) {
-	  alert("An unknown error occured; please try again or contact us.");
-	  return;
+    alert("An unknown error occured; please try again or contact us.");
+    return;
   }
   span.remove();
 }

--- a/resources/assets/js/editor.js
+++ b/resources/assets/js/editor.js
@@ -151,12 +151,18 @@ function addTab(file) {
     span.dataset.filename = file.filename;
     let text = document.createTextNode(file.filename);
     span.appendChild(text);
-    if(file.filename != 'main.py') {
+    if (file.filename !== "main.py") {
       let deleteButton = document.createElement('span');
       deleteButton.innerHTML = '&times;';
-      deleteButton.onclick = function() {
-        if(confirm('Are you sure you want to delete ' + span.dataset.filename + '?')) {
-          deleteFile(span.dataset.filename);
+      deleteButton.onclick = function(ev) {
+        ev.stopPropagation();
+        if (confirm('Are you sure you want to delete ' + file.filename + '? This operation cannot be undone!')) {
+          if (currentFilename == file.filename) {
+            currentSession = 0;
+            editor.setSession(editSessions[currentSession]);
+          }
+          deleteFile(file.filename);
+          delete Sk.builtinFiles.files["./" + file.filename];
         }
       };
       deleteButton.classList.add('smallButton');
@@ -188,7 +194,7 @@ function addTab(file) {
             readOnly: false,
             fontSize: "12pt",
             enableBasicAutocompletion: true,
-            enableSnippets: true,
+            enableSnippets: false,
             enableLiveAutocompletion: true,
         });
       }
@@ -491,14 +497,9 @@ function deleteFile(filename) {
     body: data
   };
   fetch('/sketch/' + sketchId + '/deleteFile', options)
-  .then(response => {
-    if(response.status < 200 || response.status > 299) {
-      throw response;
-    }
-    return response.json();
-  })
-  .then(deleteOldFile)
-  .catch(error => { console.log('Error: ', error); })
+    .then(response => response.json())
+    .then(deleteOldFile)
+    .catch(error => { console.log('Error: ', error); })
 }
 function deleteOldFile(response) {
   let span = document.querySelector(`.editorTab[data-filename='${response.filename}']`);

--- a/resources/assets/js/editor.js
+++ b/resources/assets/js/editor.js
@@ -154,8 +154,7 @@ function addTab(file) {
     if(file.filename != 'main.py') {
       let deleteButton = document.createElement('span');
       deleteButton.innerHTML = '&times;';
-      deleteButton.onclick = function(this) {
-        let span = this.parentNode;
+      deleteButton.onclick = function() {
         if(confirm('Are you sure you want to delete ' + span.dataset.filename + '?')) {
           deleteFile(span.dataset.filename);
         }
@@ -492,12 +491,21 @@ function deleteFile(filename) {
     body: data
   };
   fetch('/sketch/' + sketchId + '/deleteFile', options)
-    .then(response => response.json())
-    .then(deleteOldFile)
-    .catch((error) => { console.log('Error: ', error); })
+  .then(response => {
+		if(response.status < 200 || response.status > 299) {
+			throw response;
+		}
+		return response.json();
+	})
+	.then(deleteOldFile)
+  .catch(error => { console.log('Error: ', error); })
 }
 function deleteOldFile(response) {
   let span = document.querySelector(`.editorTab[data-filename='${response.filename}']`);
+  if(!span) {
+	  alert("An unknown error occured; please try again or contact us.");
+	  return;
+  }
   span.remove();
 }
 function showRename(event) {

--- a/resources/assets/js/editor.js
+++ b/resources/assets/js/editor.js
@@ -156,7 +156,9 @@ function addTab(file) {
       deleteButton.innerHTML = '&times;';
       deleteButton.onclick = function(this) {
         let span = this.parentNode;
-        deleteFile(span.dataset.filename);
+        if(confirm('Are you sure you want to delete ' + span.dataset.filename + '?')) {
+          deleteFile(span.dataset.filename);
+        }
       };
       deleteButton.classList.add('smallButton');
       span.appendChild(deleteButton);

--- a/resources/assets/js/editor.js
+++ b/resources/assets/js/editor.js
@@ -151,14 +151,16 @@ function addTab(file) {
     span.dataset.filename = file.filename;
     let text = document.createTextNode(file.filename);
     span.appendChild(text);
-    let deleteButton = document.createElement('span');
-    deleteButton.innerHTML = '×';
-    deleteButton.onclick = function(this) {
-      let span = this.parentNode;
-      deleteFile(span.dataset.filename);
-    };
-    deleteButton.classList.add('smallButton');
-    span.appendChild(deleteButton);
+    if(file.filename != 'main.py') {
+      let deleteButton = document.createElement('span');
+      deleteButton.innerHTML = '&times;';
+      deleteButton.onclick = function(this) {
+        let span = this.parentNode;
+        deleteFile(span.dataset.filename);
+      };
+      deleteButton.classList.add('smallButton');
+      span.appendChild(deleteButton);
+    }
     span.classList.add("editorTab");
     fileTabs = document.getElementById('fileTabs');
 

--- a/resources/assets/js/editor.js
+++ b/resources/assets/js/editor.js
@@ -148,7 +148,17 @@ function setupEditor(response) {
 }
 function addTab(file) {
     let span = document.createElement('span');
-    span.innerHTML = file.filename;
+    span.dataset.filename = file.filename;
+    let text = document.createTextNode(file.filename);
+    span.appendChild(text);
+    let deleteButton = document.createElement('span');
+    deleteButton.innerHTML = '×';
+    deleteButton.onclick = function(this) {
+      let span = this.parentNode;
+      deleteFile(span.dataset.filename);
+    };
+    deleteButton.classList.add('smallButton');
+    span.appendChild(deleteButton);
     span.classList.add("editorTab");
     fileTabs = document.getElementById('fileTabs');
 
@@ -465,6 +475,26 @@ function newPythonFile() {
 function addNewFile(response) {
   let file = { "filename": response.filename, "sourceCode": "" };
   addTab(file);
+}
+function deleteFile(filename) {
+  const sketchId = document.getElementById('editor').getAttribute('data-sketch-id');
+  const crsfToken = document.getElementById('editor').getAttribute('data-crsf-token');
+  const data = "filename=" + encodeURIComponent(filename) + "&sketchId=" + encodeURIComponent(sketchId) + "&crsfToken=" + encodeURIComponent(crsfToken);
+  const options = {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded'
+    },
+    body: data
+  };
+  fetch('/sketch/' + sketchId + '/deleteFile', options)
+    .then(response => response.json())
+    .then(deleteOldFile)
+    .catch((error) => { console.log('Error: ', error); })
+}
+function deleteOldFile(response) {
+  let span = document.querySelector(`.editorTab[data-filename='${response.filename}']`);
+  span.remove();
 }
 function showRename(event) {
   event.preventDefault();

--- a/resources/assets/sass/partials/sketch.css
+++ b/resources/assets/sass/partials/sketch.css
@@ -41,6 +41,20 @@
   color: white;
   padding: 10px 10px 5px 10px;
 }
+.smallButton {
+  margin: 5px;
+  padding: 5px;
+  
+  display: inline-box;
+  width: 20px;
+  height: 20px;
+  border-radius: 5px;
+  
+  background: lightgrey;
+  color: #111;
+  cursor: pointer;
+  text-align: center;
+}
 #console {
     border: 10px solid lightgray;
     margin: auto;

--- a/resources/assets/sass/partials/sketch.css
+++ b/resources/assets/sass/partials/sketch.css
@@ -41,19 +41,35 @@
   color: white;
   padding: 10px 10px 5px 10px;
 }
+.editorTab {
+  box-sizing: border-box;
+  border-top: 2px black solid;
+  border-right: 2px black solid;
+  border-left: 2px black solid;
+  background-color: #50394c;
+  color: white;
+  padding: 10px 10px 5px 10px;
+}
 .smallButton {
+  /* Funny padding/height values are so the cross is higher */
   margin: 5px;
-  padding: 5px;
+  padding: 0 5px;
   
-  display: inline-box;
-  width: 20px;
-  height: 20px;
+  display: inline-block;
+  width: 15px;
+  height: 25px;
   border-radius: 5px;
   
-  background: lightgrey;
-  color: #111;
+  background: #614A5D;
   cursor: pointer;
+  
+  color: white;
   text-align: center;
+  font-size: 20px;
+  font-family: Arial;
+}
+.smallButton:hover {
+  background: #40283B;
 }
 #console {
     border: 10px solid lightgray;

--- a/resources/assets/sass/partials/sketch.css
+++ b/resources/assets/sass/partials/sketch.css
@@ -40,24 +40,15 @@
   background-color: #50394c;
   color: white;
   padding: 10px 10px 5px 10px;
+  cursor: pointer;
 }
 .smallButton {
-  /* Funny padding/height values are so the cross is higher */
-  margin: 5px;
+  margin-left: 10px;
   padding: 0 5px;
-  
-  display: inline-block;
-  width: 15px;
-  height: 25px;
-  border-radius: 5px;
-  
+  border-radius: 100%;
   background: #614A5D;
-  cursor: pointer;
-  
   color: white;
   text-align: center;
-  font-size: 20px;
-  font-family: Arial;
 }
 .smallButton:hover {
   background: #40283B;

--- a/resources/assets/sass/partials/sketch.css
+++ b/resources/assets/sass/partials/sketch.css
@@ -41,15 +41,6 @@
   color: white;
   padding: 10px 10px 5px 10px;
 }
-.editorTab {
-  box-sizing: border-box;
-  border-top: 2px black solid;
-  border-right: 2px black solid;
-  border-left: 2px black solid;
-  background-color: #50394c;
-  color: white;
-  padding: 10px 10px 5px 10px;
-}
 .smallButton {
   /* Funny padding/height values are so the cross is higher */
   margin: 5px;
@@ -82,7 +73,7 @@
 }
 .appHeading {
   box-sizing: border-box;
-  color: #f5910f;;
+  color: #f5910f;
   text-align: center;
   padding: 10px;
   margin-top: 10px 0 0 0;

--- a/src/PyAngelo/Controllers/Sketch/SketchDeleteFileController.php
+++ b/src/PyAngelo/Controllers/Sketch/SketchDeleteFileController.php
@@ -1,0 +1,104 @@
+<?php
+// Lol I copied SketchAddFileController.php. Same thing really but different...?
+
+namespace PyAngelo\Controllers\Sketch;
+
+use PyAngelo\Auth\Auth;
+use PyAngelo\Controllers\Controller;
+use PyAngelo\Repositories\SketchRepository;
+use PyAngelo\Utilities\SketchFiles;
+use Framework\{Request, Response};
+
+class SketchDeleteFileController extends Controller {
+  protected $sketchRepository;
+
+  public function __construct(
+    Request $request,
+    Response $response,
+    Auth $auth,
+    SketchRepository $sketchRepository,
+    SketchFiles $sketchFiles
+  ) {
+    parent::__construct($request, $response, $auth);
+    $this->sketchRepository = $sketchRepository;
+    $this->sketchFiles = $sketchFiles;
+  }
+
+  public function exec() {
+    $this->response->setView('sketch/add.json.php');
+    $this->response->header('Content-Type: application/json');
+
+    if (! $this->auth->loggedIn()) {
+      $this->response->setVars(array(
+        'status' => 'info',
+        'message' => 'Log in to delete a file from a sketch.',
+        'filename' => 'File not deleted'
+      ));
+      return $this->response;
+    }
+
+    // Validate the CRSF token
+    if (!$this->auth->crsfTokenIsValid()) {
+      $this->response->setVars(array(
+        'status' => 'error',
+        'message' => 'You must delete a file from the PyAngelo website. No CORS muahahaha',
+        'filename' => 'File not deleted'
+      ));
+      return $this->response;
+    }
+
+    if (!isset($this->request->post['sketchId'])) {
+      $this->response->setVars(array(
+        'status' => 'error',
+        'message' => 'You must select a sketch to delete a file from.',
+        'filename' => 'File not deleted'
+      ));
+      return $this->response;
+    }
+
+    if (!isset($this->request->post['filename'])) {
+      $this->response->setVars(array(
+        'status' => 'error',
+        'message' => 'You must select a file to delete.',
+        'filename' => 'File not deleted'
+      ));
+      return $this->response;
+    }
+
+    if (! $sketch = $this->sketchRepository->getSketchById($this->request->post['sketchId'])) {
+      $this->response->setVars(array(
+        'status' => 'error',
+        'message' => 'You must select a valid sketch to delete a file from.',
+        'filename' => 'File not deleted'
+      ));
+      return $this->response;
+    }
+    if ($sketch['person_id'] != $this->auth->personId()) {
+      $this->response->setVars(array(
+        'status' => 'error',
+        'message' => 'You must be the owner of the sketch to delete a file from it.',
+        'filename' => 'File not delete'
+      ));
+      return $this->response;
+    }
+    
+    // Wow 83 lines just to verify the request... kinda hardcore imo
+    // *when you scroll through a 100 line code and find that the actual stuff is does in 10 lines*
+    $this->sketchRepository->deleteSketchFile(
+      $sketch['sketch_id'],
+      $this->request->post['filename']
+    );
+
+    $this->sketchFiles->deleteFile(
+      $sketch,
+      $this->request->post['filename'],
+    );
+
+    $this->response->setVars(array(
+        'status' => 'success',
+        'message' => 'File deleted.',
+        'filename' => $this->request->post['filename']
+      ));
+    return $this->response;
+  }
+}

--- a/src/PyAngelo/Controllers/Sketch/SketchDeleteFileController.php
+++ b/src/PyAngelo/Controllers/Sketch/SketchDeleteFileController.php
@@ -77,7 +77,26 @@ class SketchDeleteFileController extends Controller {
       $this->response->setVars(array(
         'status' => 'error',
         'message' => 'You must be the owner of the sketch to delete a file from it.',
-        'filename' => 'File not delete'
+        'filename' => 'File not deleted'
+      ));
+      return $this->response;
+    }
+    if ($this->request->post['filename'] == 'main.py') {
+      $this->response->setVars(array(
+        'status' => 'error',
+        'message' => 'You cannot delete main.py!',
+        'filename' => 'File not deleted'
+      ));
+      return $this->response;
+    }
+    if ($this->sketchFiles->doesFileExist(
+      $sketch,
+      $this->request->post['filename']
+    )) {
+      $this->response->setVars(array(
+        'status' => 'error',
+        'message' => 'The requested file does not exist.',
+        'filename' => 'Non-existant file not deleted'
       ));
       return $this->response;
     }
@@ -91,7 +110,7 @@ class SketchDeleteFileController extends Controller {
 
     $this->sketchFiles->deleteFile(
       $sketch,
-      $this->request->post['filename'],
+      $this->request->post['filename']
     );
 
     $this->response->setVars(array(

--- a/src/PyAngelo/Controllers/Sketch/SketchDeleteFileController.php
+++ b/src/PyAngelo/Controllers/Sketch/SketchDeleteFileController.php
@@ -1,6 +1,4 @@
 <?php
-// Lol I copied SketchAddFileController.php. Same thing really but different...?
-
 namespace PyAngelo\Controllers\Sketch;
 
 use PyAngelo\Auth\Auth;
@@ -25,7 +23,7 @@ class SketchDeleteFileController extends Controller {
   }
 
   public function exec() {
-    $this->response->setView('sketch/add.json.php');
+    $this->response->setView('sketch/delete.json.php');
     $this->response->header('Content-Type: application/json');
 
     if (! $this->auth->loggedIn()) {
@@ -41,7 +39,7 @@ class SketchDeleteFileController extends Controller {
     if (!$this->auth->crsfTokenIsValid()) {
       $this->response->setVars(array(
         'status' => 'error',
-        'message' => 'You must delete a file from the PyAngelo website. No CORS muahahaha',
+        'message' => 'You must delete a file from the PyAngelo website.',
         'filename' => 'File not deleted'
       ));
       return $this->response;
@@ -101,8 +99,6 @@ class SketchDeleteFileController extends Controller {
       return $this->response;
     }
     
-    // Wow 83 lines just to verify the request... kinda hardcore imo
-    // *when you scroll through a 100 line code and find that the actual stuff is does in 10 lines*
     $this->sketchRepository->deleteSketchFile(
       $sketch['sketch_id'],
       $this->request->post['filename']

--- a/src/PyAngelo/Controllers/Sketch/SketchDeleteFileController.php
+++ b/src/PyAngelo/Controllers/Sketch/SketchDeleteFileController.php
@@ -87,7 +87,7 @@ class SketchDeleteFileController extends Controller {
       ));
       return $this->response;
     }
-    if ($this->sketchFiles->doesFileExist(
+    if (! $this->sketchFiles->doesFileExist(
       $sketch,
       $this->request->post['filename']
     )) {

--- a/src/PyAngelo/Repositories/MysqlSketchRepository.php
+++ b/src/PyAngelo/Repositories/MysqlSketchRepository.php
@@ -143,6 +143,19 @@ class MysqlSketchRepository implements SketchRepository {
 
     return $fileId;
   }
+  
+	public function deleteSketchFile($sketchId, $filename) {
+		$sql = "DELETE
+						FROM 		sketch_files
+						WHERE 	sketch_id = ?
+						AND 		filename = ?";
+		$stmt = $this->dbh->prepare($sql);
+		$stmt->bind_param('is', $sketchId, $filename);
+		$res = $stmt->execute();
+		$stmt->close();
+		
+		return $res;
+	}
 
   public function forkSketch($sketchId, $personId, $title, $lessonId = NULL, $tutorialId = NULL) {
     $sql = "INSERT INTO sketch (

--- a/src/PyAngelo/Repositories/MysqlSketchRepository.php
+++ b/src/PyAngelo/Repositories/MysqlSketchRepository.php
@@ -151,10 +151,10 @@ class MysqlSketchRepository implements SketchRepository {
             AND     filename = ?";
     $stmt = $this->dbh->prepare($sql);
     $stmt->bind_param('is', $sketchId, $filename);
-    $res = $stmt->execute();
+    $stmt->execute();
+    $rowsDeleted = $this->dbh->affected_rows;
     $stmt->close();
-    
-    return $res;
+    return $rowsDeleted;
   }
 
   public function forkSketch($sketchId, $personId, $title, $lessonId = NULL, $tutorialId = NULL) {

--- a/src/PyAngelo/Repositories/MysqlSketchRepository.php
+++ b/src/PyAngelo/Repositories/MysqlSketchRepository.php
@@ -144,18 +144,18 @@ class MysqlSketchRepository implements SketchRepository {
     return $fileId;
   }
   
-	public function deleteSketchFile($sketchId, $filename) {
-		$sql = "DELETE
-						FROM 		sketch_files
-						WHERE 	sketch_id = ?
-						AND 		filename = ?";
-		$stmt = $this->dbh->prepare($sql);
-		$stmt->bind_param('is', $sketchId, $filename);
-		$res = $stmt->execute();
-		$stmt->close();
-		
-		return $res;
-	}
+  public function deleteSketchFile($sketchId, $filename) {
+    $sql = "DELETE
+            FROM    sketch_files
+            WHERE   sketch_id = ?
+            AND     filename = ?";
+    $stmt = $this->dbh->prepare($sql);
+    $stmt->bind_param('is', $sketchId, $filename);
+    $res = $stmt->execute();
+    $stmt->close();
+    
+    return $res;
+  }
 
   public function forkSketch($sketchId, $personId, $title, $lessonId = NULL, $tutorialId = NULL) {
     $sql = "INSERT INTO sketch (

--- a/src/PyAngelo/Repositories/SketchRepository.php
+++ b/src/PyAngelo/Repositories/SketchRepository.php
@@ -18,6 +18,8 @@ interface SketchRepository {
   public function createNewSketch($personId, $title, $lessonId = NULL);
 
   public function addSketchFile($sketchId, $filename);
+  
+  public function deleteSketchFile($sketchId, $filename);
 
   public function forkSketch($sketchId, $personId, $title);
 

--- a/src/PyAngelo/Utilities/SketchFiles.php
+++ b/src/PyAngelo/Utilities/SketchFiles.php
@@ -24,12 +24,11 @@ ENDDEFAULTMAINCODE;
   }
   
   public function doesFileExist($sketch, $filename) {
-    return file_exists($this->appDir . '/public/sketches/' . $sketch['person_id'] . '/' . $sketch['sketch_id'] . '/' . $filename); // something like that perhaps?!
+    return file_exists($this->appDir . '/public/sketches/' . $sketch['person_id'] . '/' . $sketch['sketch_id'] . '/' . $filename);
   }
   
   public function deleteFile($sketch, $filename) {
     unlink($this->appDir . '/public/sketches/' . $sketch['person_id'] . '/' . $sketch['sketch_id'] . '/' . $filename);
-    // does that work?? srsly?
   }
 
   public function saveCode($sketch, $filename, $code) {

--- a/src/PyAngelo/Utilities/SketchFiles.php
+++ b/src/PyAngelo/Utilities/SketchFiles.php
@@ -23,6 +23,10 @@ ENDDEFAULTMAINCODE;
     touch($this->appDir . '/public/sketches/' . $sketch['person_id'] . '/' . $sketch['sketch_id'] . '/' . $filename);
   }
   
+  public function doesFileExists($sketch, $filename) {
+    return file_exists($this->appDir . '/public/sketches/' . $sketch['person_id'] . '/' . $sketch['sketch_id'] . '/' . $filename); // something like that perhaps?!
+  }
+  
   public function deleteFile($sketch, $filename) {
     unlink($this->appDir . '/public/sketches/' . $sketch['person_id'] . '/' . $sketch['sketch_id'] . '/' . $filename);
     // does that work?? srsly?

--- a/src/PyAngelo/Utilities/SketchFiles.php
+++ b/src/PyAngelo/Utilities/SketchFiles.php
@@ -22,6 +22,11 @@ ENDDEFAULTMAINCODE;
   public function createFile($sketch, $filename) {
     touch($this->appDir . '/public/sketches/' . $sketch['person_id'] . '/' . $sketch['sketch_id'] . '/' . $filename);
   }
+  
+  public function deleteFile($sketch, $filename) {
+    unlink($this->appDir . '/public/sketches/' . $sketch['person_id'] . '/' . $sketch['sketch_id'] . '/' . $filename);
+    // does that work?? srsly?
+  }
 
   public function saveCode($sketch, $filename, $code) {
     $basePath = $this->appDir . '/public/sketches/' . $sketch['person_id'] . '/' . $sketch['sketch_id'];

--- a/src/PyAngelo/Utilities/SketchFiles.php
+++ b/src/PyAngelo/Utilities/SketchFiles.php
@@ -23,7 +23,7 @@ ENDDEFAULTMAINCODE;
     touch($this->appDir . '/public/sketches/' . $sketch['person_id'] . '/' . $sketch['sketch_id'] . '/' . $filename);
   }
   
-  public function doesFileExists($sketch, $filename) {
+  public function doesFileExist($sketch, $filename) {
     return file_exists($this->appDir . '/public/sketches/' . $sketch['person_id'] . '/' . $sketch['sketch_id'] . '/' . $filename); // something like that perhaps?!
   }
   

--- a/tests/src/PyAngelo/Controllers/Sketch/SketchDeleteFileControllerTest.php
+++ b/tests/src/PyAngelo/Controllers/Sketch/SketchDeleteFileControllerTest.php
@@ -1,0 +1,211 @@
+<?php
+namespace Tests\src\PyAngelo\Controllers\Sketch;
+
+use PHPUnit\Framework\TestCase;
+use Mockery;
+use Framework\Request;
+use Framework\Response;
+use PyAngelo\Repositories\SketchRepository;
+use PyAngelo\Utilities\SketchFiles;
+use PyAngelo\Controllers\Sketch\SketchDeleteFileController;
+
+class SketchDeleteFileControllerTest extends TestCase {
+  public function setUp(): void {
+    $this->request = new Request($GLOBALS);
+    $this->response = new Response('views');
+    $this->auth = Mockery::mock('PyAngelo\Auth\Auth');
+    $this->sketchRepository = Mockery::mock('PyAngelo\Repositories\SketchRepository');
+    $this->sketchFiles = Mockery::mock('PyAngelo\Utilities\SketchFiles');
+    $this->controller = new SketchDeleteFileController (
+      $this->request,
+      $this->response,
+      $this->auth,
+      $this->sketchRepository,
+      $this->sketchFiles
+    );
+  }
+  public function tearDown(): void {
+    Mockery::close();
+  }
+
+  public function testClassCanBeInstantiated() {
+    $this->assertSame(get_class($this->controller), 'PyAngelo\Controllers\Sketch\SketchDeleteFileController');
+  }
+
+  public function testWhenNotLoggedIn() {
+    $this->auth->shouldReceive('loggedIn')->once()->with()->andReturn(false);
+
+    $response = $this->controller->exec();
+    $responseVars = $response->getVars();
+    $expectedViewName = 'sketch/delete.json.php';
+    $expectedStatus = 'info';
+    $expectedMessage = 'Log in to delete a file from a sketch.';
+    $this->assertSame($expectedViewName, $response->getView());
+    $this->assertSame($expectedStatus, $responseVars['status']);
+    $this->assertSame($expectedMessage, $responseVars['message']);
+  }
+
+  public function testWhenNoCrsfToken() {
+    $this->auth->shouldReceive('loggedIn')->once()->with()->andReturn(true);
+    $this->auth->shouldReceive('crsfTokenIsValid')->once()->with()->andReturn(false);
+
+    $response = $this->controller->exec();
+    $responseVars = $response->getVars();
+    $expectedViewName = 'sketch/delete.json.php';
+    $expectedStatus = 'error';
+    $expectedMessage = 'You must delete a file from the PyAngelo website.';
+    $this->assertSame($expectedViewName, $response->getView());
+    $this->assertSame($expectedStatus, $responseVars['status']);
+    $this->assertSame($expectedMessage, $responseVars['message']);
+  }
+
+  public function testWhenNoSketchId() {
+    $this->auth->shouldReceive('loggedIn')->once()->with()->andReturn(true);
+    $this->auth->shouldReceive('crsfTokenIsValid')->once()->with()->andReturn(true);
+
+    $response = $this->controller->exec();
+    $responseVars = $response->getVars();
+    $expectedViewName = 'sketch/delete.json.php';
+    $expectedStatus = 'error';
+    $expectedMessage = 'You must select a sketch to delete a file from.';
+    $this->assertSame($expectedViewName, $response->getView());
+    $this->assertSame($expectedStatus, $responseVars['status']);
+    $this->assertSame($expectedMessage, $responseVars['message']);
+  }
+
+  public function testWhenNoFilename() {
+    $sketchId = 101;
+    $this->request->post = ['sketchId' => $sketchId];
+    $this->auth->shouldReceive('loggedIn')->once()->with()->andReturn(true);
+    $this->auth->shouldReceive('crsfTokenIsValid')->once()->with()->andReturn(true);
+    $response = $this->controller->exec();
+    $responseVars = $response->getVars();
+    $expectedViewName = 'sketch/delete.json.php';
+    $expectedStatus = 'error';
+    $expectedMessage = 'You must select a file to delete.';
+    $this->assertSame($expectedViewName, $response->getView());
+    $this->assertSame($expectedStatus, $responseVars['status']);
+    $this->assertSame($expectedMessage, $responseVars['message']);
+  }
+
+  public function testSketchNotInDatabase() {
+    $sketchId = 101;
+    $filename = 'main.py';
+    $this->request->post = [
+      'sketchId' => $sketchId,
+      'filename' => $filename
+    ];
+    $this->auth->shouldReceive('loggedIn')->once()->with()->andReturn(true);
+    $this->auth->shouldReceive('crsfTokenIsValid')->once()->with()->andReturn(true);
+    $this->sketchRepository->shouldReceive('getSketchById')->once()->with($sketchId)->andReturn(NULL);
+
+    $response = $this->controller->exec();
+    $responseVars = $response->getVars();
+    $expectedViewName = 'sketch/delete.json.php';
+    $expectedStatus = 'error';
+    $expectedMessage = 'You must select a valid sketch to delete a file from.';
+    $this->assertSame($expectedViewName, $response->getView());
+    $this->assertSame($expectedStatus, $responseVars['status']);
+    $this->assertSame($expectedMessage, $responseVars['message']);
+  }
+
+  public function testSketchNotOwner() {
+    $ownerId = 101;
+    $personId = 102;
+    $sketchId = 10;
+    $filename = 'main.py';
+    $sketch = ['sketch_id' => $sketchId, 'person_id' => $ownerId];
+    $this->request->post = [
+      'sketchId' => $sketchId,
+      'filename' => $filename
+    ];
+    $this->auth->shouldReceive('loggedIn')->once()->with()->andReturn(true);
+    $this->auth->shouldReceive('crsfTokenIsValid')->once()->with()->andReturn(true);
+    $this->auth->shouldReceive('personId')->once()->with()->andReturn($personId);
+    $this->sketchRepository->shouldReceive('getSketchById')->once()->with($sketchId)->andReturn($sketch);
+
+    $response = $this->controller->exec();
+    $responseVars = $response->getVars();
+    $expectedViewName = 'sketch/delete.json.php';
+    $expectedStatus = 'error';
+    $expectedMessage = 'You must be the owner of the sketch to delete a file from it.';
+    $this->assertSame($expectedViewName, $response->getView());
+    $this->assertSame($expectedStatus, $responseVars['status']);
+    $this->assertSame($expectedMessage, $responseVars['message']);
+  }
+  
+  public function testFileNotMainFile() {
+    $sketchId = 10;
+    $filename = 'main.py';
+    $this->request->post = [
+      'sketchId' => $sketchId,
+      'filename' => $filename
+    ];
+    $this->auth->shouldReceive('loggedIn')->once()->with()->andReturn(true);
+    $this->auth->shouldReceive('crsfTokenIsValid')->once()->with()->andReturn(true);
+    $this->sketchRepository->shouldReceive('getSketchById')->once()->with($sketchId)->andReturn(NULL);
+    
+    $response = $this->controller->exec();
+    $responseVars = $response->getVars();
+    $expectedViewName = 'sketch/delete.json.php';
+    $expectedStatus = 'error';
+    $expectedMessage = 'You cannot delete main.py!';
+    $this->assertSame($expectedViewName, $response->getView());
+    $this->assertSame($expectedStatus, $responseVars['status']);
+    $this->assertSame($expectedMessage, $responseVars['message']);
+  }
+  
+  public function testFileDoesNotExist() {
+    $sketchId = 10;
+    $filename = 'randomFile.py';
+    $this->request->post = [
+      'sketchId' => $sketchId,
+      'filename' => $filename
+    ];
+    $this->auth->shouldReceive('loggedIn')->once()->with()->andReturn(true);
+    $this->auth->shouldReceive('crsfTokenIsValid')->once()->with()->andReturn(true);
+    $this->sketchRepository->shouldReceive('getSketchById')->once()->with($sketchId)->andReturn(NULL);
+    
+    $response = $this->controller->exec();
+    $responseVars = $response->getVars();
+    $expectedViewName = 'sketch/delete.json.php';
+    $expectedStatus = 'error';
+    $expectedMessage = 'The requested file does not exist.';
+    $this->assertSame($expectedViewName, $response->getView());
+    $this->assertSame($expectedStatus, $responseVars['status']);
+    $this->assertSame($expectedMessage, $responseVars['message']);
+  }
+
+  public function testSuccess() {
+    $ownerId = 101;
+    $personId = $ownerId;
+    $sketchId = 220;
+    $fileId = 1000;
+    $filename = 'randomFile.py';
+    $sketch = [
+        'sketch_id' => $sketchId,
+        'person_id' => $personId,
+        'title' => 'random-title'
+    ];
+    $this->request->post = [
+      'sketchId' => $sketchId,
+      'filename' => $filename
+    ];
+    $this->auth->shouldReceive('loggedIn')->once()->with()->andReturn(true);
+    $this->auth->shouldReceive('crsfTokenIsValid')->once()->with()->andReturn(true);
+    $this->auth->shouldReceive('personId')->once()->with()->andReturn($personId);
+    $this->sketchRepository->shouldReceive('getSketchById')->once()->with($sketchId)->andReturn($sketch);
+    $this->sketchRepository->shouldReceive('deleteSketchFile')->once()->with($sketchId, $filename)->andReturn();
+    $this->sketchFiles->shouldReceive('deleteFile')->once()->with($sketch, $filename)->andReturn();
+
+    $response = $this->controller->exec();
+    $responseVars = $response->getVars();
+    $expectedViewName = 'sketch/delete.json.php';
+    $expectedStatus = 'success';
+    $expectedMessage = 'File deleted.';
+    $this->assertSame($expectedViewName, $response->getView());
+    $this->assertSame($expectedStatus, $responseVars['status']);
+    $this->assertSame($expectedMessage, $responseVars['message']);
+  }
+}
+?>

--- a/tests/src/PyAngelo/Controllers/Sketch/SketchDeleteFileControllerTest.php
+++ b/tests/src/PyAngelo/Controllers/Sketch/SketchDeleteFileControllerTest.php
@@ -134,17 +134,25 @@ class SketchDeleteFileControllerTest extends TestCase {
     $this->assertSame($expectedMessage, $responseVars['message']);
   }
   
-  public function testFileNotMainFile() {
-    $sketchId = 10;
+  public function testAttemptDeleteMain() {
+    $personId = 101;
+    $ownerId = 101;
+    $sketchId = 101;
     $filename = 'main.py';
+    $this->request->post = [
+      'sketchId' => $sketchId,
+      'filename' => $filename
+    ];
+    $sketch = ['sketch_id' => $sketchId, 'person_id' => $ownerId];
     $this->request->post = [
       'sketchId' => $sketchId,
       'filename' => $filename
     ];
     $this->auth->shouldReceive('loggedIn')->once()->with()->andReturn(true);
     $this->auth->shouldReceive('crsfTokenIsValid')->once()->with()->andReturn(true);
-    $this->sketchRepository->shouldReceive('getSketchById')->once()->with($sketchId)->andReturn(NULL);
-    
+    $this->auth->shouldReceive('personId')->once()->with()->andReturn($personId);
+    $this->sketchRepository->shouldReceive('getSketchById')->once()->with($sketchId)->andReturn($sketch);
+
     $response = $this->controller->exec();
     $responseVars = $response->getVars();
     $expectedViewName = 'sketch/delete.json.php';
@@ -156,16 +164,25 @@ class SketchDeleteFileControllerTest extends TestCase {
   }
   
   public function testFileDoesNotExist() {
+    $ownerId = 101;
+    $personId = $ownerId;
     $sketchId = 10;
     $filename = 'randomFile.py';
     $this->request->post = [
       'sketchId' => $sketchId,
       'filename' => $filename
     ];
+    $sketch = ['sketch_id' => $sketchId, 'person_id' => $ownerId];
+    $this->request->post = [
+      'sketchId' => $sketchId,
+      'filename' => $filename
+    ];
     $this->auth->shouldReceive('loggedIn')->once()->with()->andReturn(true);
     $this->auth->shouldReceive('crsfTokenIsValid')->once()->with()->andReturn(true);
-    $this->sketchRepository->shouldReceive('getSketchById')->once()->with($sketchId)->andReturn(NULL);
-    
+    $this->auth->shouldReceive('personId')->once()->with()->andReturn($personId);
+    $this->sketchRepository->shouldReceive('getSketchById')->once()->with($sketchId)->andReturn($sketch);
+    $this->sketchFiles->shouldReceive('doesFileExist')->once()->with($sketch, $filename)->andReturn(false);
+
     $response = $this->controller->exec();
     $responseVars = $response->getVars();
     $expectedViewName = 'sketch/delete.json.php';
@@ -196,6 +213,7 @@ class SketchDeleteFileControllerTest extends TestCase {
     $this->auth->shouldReceive('personId')->once()->with()->andReturn($personId);
     $this->sketchRepository->shouldReceive('getSketchById')->once()->with($sketchId)->andReturn($sketch);
     $this->sketchRepository->shouldReceive('deleteSketchFile')->once()->with($sketchId, $filename)->andReturn();
+    $this->sketchFiles->shouldReceive('doesFileExist')->once()->with($sketch, $filename)->andReturn(true);
     $this->sketchFiles->shouldReceive('deleteFile')->once()->with($sketch, $filename)->andReturn();
 
     $response = $this->controller->exec();

--- a/tests/views/sketch/SketchDeleteJsonTest.php
+++ b/tests/views/sketch/SketchDeleteJsonTest.php
@@ -17,7 +17,7 @@ class SketchDeleteJsonTest extends TestCase {
     $output = $response->requireView();
     $expect = '"status":"success"';
     $this->assertStringContainsString($expect, $output);
-    $expect = '"message":"file added"';
+    $expect = '"message":"file deleted"';
     $this->assertStringContainsString($expect, $output);
     $expect = '"filename":"main.py"';
     $this->assertStringContainsString($expect, $output);

--- a/tests/views/sketch/SketchDeleteJsonTest.php
+++ b/tests/views/sketch/SketchDeleteJsonTest.php
@@ -1,0 +1,26 @@
+<?php
+namespace Tests\views\sketch;
+
+use PHPUnit\Framework\TestCase;
+use Framework\Response;
+
+class SketchDeleteJsonTest extends TestCase {
+
+  public function testBasicView() {
+    $response = new Response('views');
+    $response->setView('sketch/delete.json.php');
+    $response->setVars(array(
+      'status' => "success",
+      'message' => "file deleted",
+      'filename' => "main.py"
+    ));
+    $output = $response->requireView();
+    $expect = '"status":"success"';
+    $this->assertStringContainsString($expect, $output);
+    $expect = '"message":"file added"';
+    $this->assertStringContainsString($expect, $output);
+    $expect = '"filename":"main.py"';
+    $this->assertStringContainsString($expect, $output);
+  }
+}
+?>

--- a/views/sketch/delete.json.php
+++ b/views/sketch/delete.json.php
@@ -1,0 +1,5 @@
+{
+  "status":"<?= $this->esc($status); ?>",
+  "message":"<?= $this->esc($message); ?>",
+  "filename":"<?= $this->esc($filename); ?>"
+}


### PR DESCRIPTION
Have no idea what I’m doing. I’ve looked at other similar bits of code and I hope that this is how it’s meant to be done, since I have no understanding on how PyAngelo’s back-end functions.

This should _(should)_ allow users to delete files on their sketches, apart from the main.py file. It will give them a confirmation warning (thx Habbison) and the delete buttons are nicely styled (at least they are for me).

Probably got some things wrong, forgot some things or made some typos, so please check over because I have most likely done something wrong somewhere!