### PR TITLE
Editor tabs now show current file

### DIFF
--- a/resources/assets/js/editor.js
+++ b/resources/assets/js/editor.js
@@ -179,6 +179,9 @@ function addTab(file) {
       span.appendChild(deleteButton);
     }
     span.classList.add("editorTab");
+    if(file.filename === "main.py") {
+      span.classList.add("current");
+    }
     fileTabs = document.getElementById('fileTabs');
 
     if (file.filename.endsWith(".py")) {
@@ -222,6 +225,9 @@ function loadSession(ev) {
   currentFilename = ev.target.getAttribute("data-filename");
   currentSession = ev.target.getAttribute("data-editor-session");
   editor.setSession(editSessions[currentSession]);
+  
+  document.querySelector(".editorTab.current").classList.remove("current");
+  document.querySelector(`.editorTab[data-filename='${currentFilename}']`).classList.add("current");
 }
 function newPythonFile() {
   const moduleNames = [

--- a/resources/assets/js/editor.js
+++ b/resources/assets/js/editor.js
@@ -179,7 +179,7 @@ function addTab(file) {
       span.appendChild(deleteButton);
     }
     span.classList.add("editorTab");
-    if(file.filename === "main.py") {
+    if (file.filename === "main.py") {
       span.classList.add("current");
     }
     fileTabs = document.getElementById('fileTabs');
@@ -225,9 +225,8 @@ function loadSession(ev) {
   currentFilename = ev.target.getAttribute("data-filename");
   currentSession = ev.target.getAttribute("data-editor-session");
   editor.setSession(editSessions[currentSession]);
-  
   document.querySelector(".editorTab.current").classList.remove("current");
-  document.querySelector(`.editorTab[data-filename='${currentFilename}']`).classList.add("current");
+  ev.target.classList.add("current");
 }
 function newPythonFile() {
   const moduleNames = [

--- a/resources/assets/sass/partials/sketch.css
+++ b/resources/assets/sass/partials/sketch.css
@@ -53,6 +53,17 @@
 .smallButton:hover {
   background: #40283B;
 }
+.editorTab.current {
+  background-color: #FEEF96;
+  color: #50394C;
+}
+.editorTab.current .smallButton {
+  background: #DCCD74;
+  color: #50394C;
+}
+.editorTab.current .smallButton:hover {
+  background: #BAAB52;
+}
 #console {
     border: 10px solid lightgray;
     margin: auto;

--- a/resources/assets/sass/partials/sketch.css
+++ b/resources/assets/sass/partials/sketch.css
@@ -21,25 +21,21 @@
   outline: none;
 }
 #editor {
-    border: 1px solid lightgray;
+    border: 2px solid lightgray;
     margin: auto;
     width: 100%;
     height: 600px;
     resize: vertical;
 }
-#fileTabs {
-  border-bottom: 2px solid black;
-  margin: 0;
-  padding: 0;
-}
 .editorTab {
-  box-sizing: border-box;
-  border-top: 2px black solid;
-  border-right: 2px black solid;
-  border-left: 2px black solid;
+  border-top: 2px #614A5D solid;
+  border-right: 2px #614A5D solid;
+  border-left: 2px #614A5D solid;
+  border-radius: 10px 10px 0 0;
   background-color: #50394c;
   color: white;
-  padding: 10px 10px 5px 10px;
+  padding: 10px;
+  margin-right: 5px;
   cursor: pointer;
 }
 .smallButton {
@@ -54,6 +50,9 @@
   background: #40283B;
 }
 .editorTab.current {
+  border-top: 2px #EDDE85 solid;
+  border-right: 2px #EDDE85 solid;
+  border-left: 2px #EDDE85 solid;
   background-color: #FEEF96;
   color: #50394C;
 }


### PR DESCRIPTION
The selected file tab will be the PyAngelo yellow, and the delete button will be a slightly darker yellow that will be a bit more slightly darker when hovered over. I’ve tested the styling, and it looks good (to me), and I’ve tested the JS when switching tabs.

Fixes #84