### PR TITLE
Skulpt js files now included as a dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6731,9 +6731,9 @@
       }
     },
     "node_modules/jsbi": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/jsbi/-/jsbi-3.2.1.tgz",
-      "integrity": "sha512-NzcT09wuJReIO829enrY3yRdHFz+ciVIq01PCGPkHlwIv5Dj9v2F4daQ4akwuPHf6xO/oii4Jrd3BsPepOxXrg==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/jsbi/-/jsbi-3.2.4.tgz",
+      "integrity": "sha512-iOygwxPzMYli5xrjfd83Vy4Wyu9Ovpw6wWWFy5Kj7XP+pZxPp7Cy72F92iAt2j+6tTDYunvLtC+2tH3xCX37ng==",
       "dev": true
     },
     "node_modules/jsesc": {
@@ -9863,7 +9863,7 @@
     },
     "node_modules/skulpt": {
       "version": "1.2.0",
-      "resolved": "git+ssh://git@github.com/pingskills/skulpt.git#e0f658b18c332d4f24e9e4b17c17f9eab18f8b81",
+      "resolved": "git+ssh://git@github.com/pingskills/skulpt.git#0600ed9916c5e95a0152466b380de615858be176",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -16534,9 +16534,9 @@
       }
     },
     "jsbi": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/jsbi/-/jsbi-3.2.1.tgz",
-      "integrity": "sha512-NzcT09wuJReIO829enrY3yRdHFz+ciVIq01PCGPkHlwIv5Dj9v2F4daQ4akwuPHf6xO/oii4Jrd3BsPepOxXrg==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/jsbi/-/jsbi-3.2.4.tgz",
+      "integrity": "sha512-iOygwxPzMYli5xrjfd83Vy4Wyu9Ovpw6wWWFy5Kj7XP+pZxPp7Cy72F92iAt2j+6tTDYunvLtC+2tH3xCX37ng==",
       "dev": true
     },
     "jsesc": {
@@ -18900,9 +18900,9 @@
       "dev": true
     },
     "skulpt": {
-      "version": "git+ssh://git@github.com/pingskills/skulpt.git#e0f658b18c332d4f24e9e4b17c17f9eab18f8b81",
+      "version": "git+ssh://git@github.com/pingskills/skulpt.git#0600ed9916c5e95a0152466b380de615858be176",
       "dev": true,
-      "from": "skulpt@github:pingskills/skulpt#pyangelo",
+      "from": "skulpt@pingskills/skulpt#pyangelo",
       "requires": {
         "jsbi": "^3.1.4"
       }

--- a/resources/assets/js/SkulptSetup.js
+++ b/resources/assets/js/SkulptSetup.js
@@ -1,4 +1,4 @@
-import Sk from 'Sk'
+const Sk = require('skulpt')
 
 Sk.preparePyAngeloPage()
 

--- a/resources/assets/js/SkulptSketch.js
+++ b/resources/assets/js/SkulptSketch.js
@@ -1,6 +1,6 @@
 import { runSkulpt, stopSkulpt } from './SkulptSetup'
 import { Editor } from './EditorSetup'
-import Sk from 'Sk'
+const Sk = require('skulpt')
 
 const editorWindow = document.getElementById('editor')
 const crsfToken = editorWindow.getAttribute('data-crsf-token')

--- a/resources/assets/js/SkulptSketchCanvasOnly.js
+++ b/resources/assets/js/SkulptSketchCanvasOnly.js
@@ -1,6 +1,6 @@
 import { runSkulpt } from './SkulptSetup'
 import { Editor } from './EditorSetup'
-import Sk from 'Sk'
+const Sk = require('skulpt')
 
 const editorWindow = document.getElementById('editor')
 const crsfToken = editorWindow.getAttribute('data-crsf-token')

--- a/resources/assets/js/playground.js
+++ b/resources/assets/js/playground.js
@@ -1,6 +1,6 @@
 import { runSkulpt, stopSkulpt } from './SkulptSetup'
 import { Editor } from './EditorSetup'
-import Sk from 'Sk'
+const Sk = require('skulpt')
 
 // Only one session in playground
 const session = 0

--- a/views/layout/header.html.php
+++ b/views/layout/header.html.php
@@ -30,11 +30,6 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.4.12/mode-python.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.4.12/ext-language_tools.min.js"></script>
 
-  <!-- Skulpt Files
-  –––––––––––––––––––––––––––––––––––––––––––––––––– -->
-  <script src="<?= mix('js/skulpt.min.js'); ?>"></script>
-  <script src="<?= mix('js/skulpt-stdlib.js'); ?>"></script>
-
   <?php endif; ?>
 
   <script src="<?= mix('js/app.js'); ?>"></script>

--- a/views/sketch/playground.html.php
+++ b/views/sketch/playground.html.php
@@ -8,11 +8,6 @@ include __DIR__ . DIRECTORY_SEPARATOR . '../layout/navbar.html.php';
   <script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.4.12/mode-python.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.4.12/ext-language_tools.min.js"></script>
 
-  <!-- Skulpt Files
-  –––––––––––––––––––––––––––––––––––––––––––––––––– -->
-  <script src="<?= mix('js/skulpt.min.js'); ?>"></script>
-  <script src="<?= mix('js/skulpt-stdlib.js'); ?>"></script>
-
   <div class="container">
     <div class="row">
       <div class="col-md-12">

--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -31,8 +31,5 @@ require('laravel-mix-eslint');
      .copy('./resources/assets/js/userSearch.js', './public/js/')
      .copy('./resources/assets/js/subscription.js', './public/js/')
      .copy('./resources/assets/js/new-payment-method.js', './public/js/')
-     .copy('./node_modules/skulpt/dist/skulpt.min.js', './public/js/')
-     .copy('./node_modules/skulpt/dist/skulpt.min.js.map', './public/js/')
-     .copy('./node_modules/skulpt/dist/skulpt-stdlib.js', './public/js/')
      .eslint()
      .version();


### PR DESCRIPTION
Instead of loading the skulpt.min.js and skulpt-stdlib.js files
separately in the head section of the HTML, these are now included in
the js files that need them as a dependency using require. I am not sure
if this can be done using the ES6 import command.