### PR TITLE
Make monitoring errors a method of Editor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9863,7 +9863,7 @@
     },
     "node_modules/skulpt": {
       "version": "1.2.0",
-      "resolved": "git+ssh://git@github.com/pingskills/skulpt.git#86ee244654674e571ed3be1c05025e9049dee590",
+      "resolved": "git+ssh://git@github.com/pingskills/skulpt.git#1f38e7a14f584ed9e8f9c947e750968320aef890",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -18900,7 +18900,7 @@
       "dev": true
     },
     "skulpt": {
-      "version": "git+ssh://git@github.com/pingskills/skulpt.git#86ee244654674e571ed3be1c05025e9049dee590",
+      "version": "git+ssh://git@github.com/pingskills/skulpt.git#1f38e7a14f584ed9e8f9c947e750968320aef890",
       "dev": true,
       "from": "skulpt@pingskills/skulpt#pyangelo",
       "requires": {

--- a/resources/assets/js/SkulptSketch.js
+++ b/resources/assets/js/SkulptSketch.js
@@ -27,42 +27,7 @@ if (!isReadOnly) {
 const aceEditor = new Editor(sketchId, crsfToken, Sk, fileTabs, isReadOnly)
 Sk.PyAngelo.aceEditor = aceEditor
 aceEditor.loadCode()
-aceEditor.editor.on('change', function (delta) {
-  Sk.PyAngelo.aceEditor.editor.getSession().clearAnnotations()
-  Sk.configure({
-    __future__: Sk.python3
-  })
-  try {
-    Sk.compile(
-      aceEditor.getCode(aceEditor.currentSession),
-      aceEditor.currentFilename,
-      'exec',
-      true
-    )
-  } catch (err) {
-    if (err.traceback) {
-      const lineno = err.traceback[0].lineno
-      const colno = err.traceback[0].colno
-      console.log(err)
-      console.log(lineno)
-      console.log(colno)
-      let errorMessage
-      if (err.message) {
-        errorMessage = err.message
-      } else if (err.nativeError) {
-        errorMessage = err.nativeError.message
-      } else {
-        errorMessage = err.toString()
-      }
-      Sk.PyAngelo.aceEditor.editor.getSession().setAnnotations([{
-        row: lineno - 1,
-        column: colno,
-        text: errorMessage,
-        type: 'error'
-      }])
-    }
-  }
-})
+aceEditor.monitorErrorsOnChange()
 
 const startStopButton = document.getElementById('startStop')
 startStopButton.addEventListener('click', saveThenRun)
@@ -457,7 +422,6 @@ function updateWebPage (response) {
     paraUploadError.innerText = response.message
     paraUploadError.style.color = 'red'
     document.getElementById('gallery').appendChild(paraUploadError)
-    console.log(response)
   }
 }
 

--- a/resources/assets/js/playground.js
+++ b/resources/assets/js/playground.js
@@ -13,6 +13,7 @@ const fileTabs = null
 
 const aceEditor = new Editor(sketchId, crsfToken, Sk, fileTabs, isReadOnly)
 Sk.PyAngelo.aceEditor = aceEditor
+aceEditor.monitorErrorsOnChange()
 
 const startStopButton = document.getElementById('startStop')
 startStopButton.addEventListener('click', runCode)


### PR DESCRIPTION
This means if another script wishes to monitor for errors in the ace
editor they can call monitorErrorsOnChange(). The SkulpSketch.js and
playground.js now do exactly this whereas SkulptSketchCanvasOnly.js does
not.