### PR TITLE
Fix split grid in column mode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9615,7 +9615,7 @@
     },
     "node_modules/skulpt": {
       "version": "1.2.0",
-      "resolved": "git+ssh://git@github.com/pingskills/skulpt.git#33ca7ba69903a4a0461780c23f7567b11b37aabe",
+      "resolved": "git+ssh://git@github.com/pingskills/skulpt.git#4067bfd823c64371b7bc8bc693a8d4bea072cdb0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -18424,7 +18424,7 @@
       "dev": true
     },
     "skulpt": {
-      "version": "git+ssh://git@github.com/pingskills/skulpt.git#33ca7ba69903a4a0461780c23f7567b11b37aabe",
+      "version": "git+ssh://git@github.com/pingskills/skulpt.git#4067bfd823c64371b7bc8bc693a8d4bea072cdb0",
       "dev": true,
       "from": "skulpt@pingskills/skulpt#pyangelo",
       "requires": {

--- a/resources/assets/sass/partials/sketch.css
+++ b/resources/assets/sass/partials/sketch.css
@@ -64,11 +64,10 @@
 #console {
     border: 2px solid lightgray;
     margin: auto;
-    font-size: 16px;
     width: 100%;
     height: 100%;
-    overflow-y: auto;
-    background-color: rgba(0, 0, 0, 1);
+    background-color: rgba(40, 42, 54, 1);
+    font-size: 16px;
 }
 #debugButtons, #debugTableWrapper {
     display: none;

--- a/views/sketch/sketch-split-editor-console.html.php
+++ b/views/sketch/sketch-split-editor-console.html.php
@@ -9,7 +9,5 @@
       <?php else : ?>
         <div class="gutter-row-1"></div>
       <?php endif; ?>
-      <div>
-        <pre id="console"></pre>
-      </div>
+      <pre id="console"></pre>
     </div><!-- editorWrapper grid -->


### PR DESCRIPTION
The console is a <pre> element and was wrapped in a <div> but this
caused issues. Now the <pre> is the element that the split grid is using
and it seems to work well.