### PR TITLE
Debugger will not step into unless code in editor

### DIFF
--- a/resources/assets/js/SkulptSetup.js
+++ b/resources/assets/js/SkulptSetup.js
@@ -178,6 +178,8 @@ export function runSkulpt (code, debugging, stopFunction) {
         Sk.PyAngelo.aceEditor.currentFilename = editSession.getAttribute('data-filename')
         Sk.PyAngelo.aceEditor.setSession(Sk.PyAngelo.aceEditor.currentSession)
         Sk.PyAngelo.aceEditor.gotoLine(currentLineNo)
+      } else {
+        return Promise.resolve(susp.resume())
       }
       const debugGlobals = {}
       const debugLocals = {}


### PR DESCRIPTION
If the filename returned by the suspension is not a file that is
currenty in the PyAngelo editor, then we simply return the suspension
from the lineStepper() function as we cannot go to the line number of a
function that is not in the editor.