### PR TITLE
Debugger handles variables using reserved words

### DIFF
--- a/resources/assets/js/makeTable.js
+++ b/resources/assets/js/makeTable.js
@@ -5,14 +5,22 @@ export function populateTable (tableBody, globals, locals) {
   for (const key in globals) {
     const row = tableBody.insertRow()
     row.insertCell().appendChild(document.createTextNode(globals[key].scope))
-    row.insertCell().appendChild(document.createTextNode(key))
+    if (key.endsWith('_$rw$')) {
+      row.insertCell().appendChild(document.createTextNode(key.slice(0, -5)))
+    } else {
+      row.insertCell().appendChild(document.createTextNode(key))
+    }
     row.insertCell().appendChild(document.createTextNode(globals[key].value))
     row.insertCell().appendChild(document.createTextNode(globals[key].type))
   }
   for (const key in locals) {
     const row = tableBody.insertRow()
     row.insertCell().appendChild(document.createTextNode(locals[key].scope))
-    row.insertCell().appendChild(document.createTextNode(key))
+    if (key.endsWith('_$rw$')) {
+      row.insertCell().appendChild(document.createTextNode(key.slice(0, -5)))
+    } else {
+      row.insertCell().appendChild(document.createTextNode(key))
+    }
     row.insertCell().appendChild(document.createTextNode(locals[key].value))
     row.insertCell().appendChild(document.createTextNode(locals[key].type))
   }


### PR DESCRIPTION
The skulpt compiler addes _$rw$ to any variable names that are reserve
words in JavaScript but the debugger should display the original name.