### PR TITLE
Enable use of turtle module

### DIFF
--- a/resources/assets/js/SkulptSetup.js
+++ b/resources/assets/js/SkulptSetup.js
@@ -86,6 +86,7 @@ export function stopSkulpt () {
 }
 
 export function runSkulpt (code, debugging, stopFunction) {
+  (Sk.TurtleGraphics || (Sk.TurtleGraphics = {})).target = 'turtleDiv'
   Sk.PyAngelo.aceEditor.setReadOnly(true)
   _stopExecution = false
   if (debugging) {

--- a/views/sketch/playground.html.php
+++ b/views/sketch/playground.html.php
@@ -38,6 +38,7 @@ include __DIR__ . DIRECTORY_SEPARATOR . '../layout/navbar.html.php';
       include 'sketch-split-editor-console.html.php';
       include 'sketch-debug-table.html.php';
       include 'sketch-output.html.php';
+      include 'sketch-turtle.html.php';
       include 'sketch-buttons.html.php';
     ?>
     <script src="<?= mix('js/playground.js'); ?>"></script>

--- a/views/sketch/show.html.php
+++ b/views/sketch/show.html.php
@@ -10,6 +10,7 @@ include 'sketch-file-tabs.html.php';
 include 'sketch-split-editor-console.html.php';
 include 'sketch-debug-table.html.php';
 include 'sketch-output.html.php';
+include 'sketch-turtle.html.php';
 include 'sketch-buttons.html.php';
 include 'sketch-upload.html.php';
 ?>

--- a/views/sketch/sketch-turtle.html.php
+++ b/views/sketch/sketch-turtle.html.php
@@ -1,0 +1,8 @@
+    <!-- output -->
+    <div class="row">
+      <div class="col-md-12">
+        <div id="turtleDiv">
+        </div><!-- turtleDiv -->
+      </div><!-- col-md-12 -->
+    </div><!-- row -->
+


### PR DESCRIPTION
The turtle module in Skulpt requires a <div> be setup which can host the
required canvases. This needs to be different from the PyAngelo canvas
since it removes any children element of the div and then creates
canvases on the fly as required.