### PR TITLE
Update the default yAxisMode to be CARTESIAN

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9588,7 +9588,7 @@
     },
     "node_modules/skulpt": {
       "version": "1.2.0",
-      "resolved": "git+ssh://git@github.com/pingskills/skulpt.git#0aa964097dbd4b5640b85fac40a06f5c49b03e08",
+      "resolved": "git+ssh://git@github.com/pingskills/skulpt.git#3990a7ae48b898f54c1f695a77c6dcbdce25723f",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -18290,7 +18290,7 @@
       "dev": true
     },
     "skulpt": {
-      "version": "git+ssh://git@github.com/pingskills/skulpt.git#0aa964097dbd4b5640b85fac40a06f5c49b03e08",
+      "version": "git+ssh://git@github.com/pingskills/skulpt.git#3990a7ae48b898f54c1f695a77c6dcbdce25723f",
       "dev": true,
       "from": "skulpt@pingskills/skulpt#pyangelo",
       "requires": {

--- a/views/reference/basic-shapes.html.php
+++ b/views/reference/basic-shapes.html.php
@@ -8,7 +8,7 @@ rect(10, 20, 50, 25)
 </pre>
 <h4>Description</h4>
 <p>
-Draws a rectangle on the canvas. By default, the first two parameters set the location of the upper-left corner, the third sets the width, and the fourth sets the height. The way these parameters are interpreted, may be changed with the <a href="#rectMode">rectMode()</a> function.
+Draws a rectangle on the canvas. By default, the first two parameters set the location of the bottom left corner, the third sets the width, and the fourth sets the height. The way these parameters are interpreted, may be changed with the <a href="#rectMode">rectMode()</a> function. If the setCanvasSize() function is called and sets the yAxisMode to JAVASCRIPT, then the first two parameters specify the top left corner of the rectangle.
 </p>
 <h4>Syntax</h4>
 <p>rect(x, y, w, h)</p>
@@ -200,8 +200,8 @@ rect(30, 30, 60, 60)
 <h4>Description</h4>
 <p>
 Changes the way the rect() function uses the paramters passed to it.</p>
-<p>The default mode is CORNER, which indicates that the first two parameters are the coordinates of the top left corner, and the third and fourth parameters specify the width and the height.</p>
-<p>The mode CORNERS indicates the first two parameters are the coordinates of the top left corner, and the third and fourth specify the bottom right coordinates.</p>
+<p>The default mode is CORNER, which indicates that the first two parameters are the coordinates of the bottom left corner, and the third and fourth parameters specify the width and the height. If the setCanvasSize() function is called specifying to set the yAxisMode to JAVASCRIPT, then the first two parameters represent the top left corner.</p>
+<p>The mode CORNERS indicates the first two parameters are the coordinates of the bottom left corner, and the third and fourth specify the top right coordinate.</p>
 <p>The mode CENTER indicates the first two parameters are the coordinates of the center of the rectangle, and the third and fourth specify the width and height.</p>
 <h4>Syntax</h4>
 <p>rectMode(mode)</p>
@@ -225,7 +225,7 @@ circle(100, 100, 50)
 <p>
 Changes the way the circle(), ellipse(), and arc() functions use the paramters passed to them.</p>
 <p>The default mode is CENTER, which indicates that the first two parameters are the coordinates of the center of the shape. The remaining parameters refer to the radius for the circle() function, and the X radius and Y radius for the ellipse() and arc() functions.</p>
-<p>The mode CORNER indicates the first two parameters are the coordinates of the top left corner of the shape. The meaning of any extra parameters remain unchanged.</p>
+<p>The mode CORNER indicates the first two parameters are the coordinates of the bottom left corner of the shape. The meaning of any extra parameters remain unchanged.</p>
 <h4>Syntax</h4>
 <p>circleMode(mode)</p>
 <h4>Parameters</h4>

--- a/views/reference/canvas.html.php
+++ b/views/reference/canvas.html.php
@@ -6,14 +6,14 @@ setCanvasSize(640, 360)
 </pre>
 <h4>Description</h4>
 <p>
-Sets the size of the canvas that all drawings are written to. The first parameter specifies the width in pixels and the second the height. The third parameter is optional and specifies the direction of the y-axis. The constant CARTESIAN can be used to specify a y-axis that is used in maths and a constant of JAVASCRIPT can be used to specify the regular javascript y-axis which moves down the screen.
+Sets the size of the canvas that all drawings are written to. The first parameter specifies the width in pixels and the second the height. The third parameter is optional and specifies the direction of the y-axis. The constant CARTESIAN can be used to specify a y-axis that is used in maths and a constant of JAVASCRIPT can be used to specify the regular javascript y-axis which moves down the screen. If no value is provided as the third parameter, a default of CARTESIAN is used.
 </p>
 <h4>Syntax</h4>
 <p>setCanvasSize(w, h, yAxisMode)</p>
 <h4>Parameters</h4>
 <p>w - The width of the canvas in pixels.</p>
 <p>h - The height of the canvas in pixels.</p>
-<p>yAxisMode - Used to set the direction of the y-axis. Use the constants CARTESIAN or JAVASCRIPT.</p>
+<p>yAxisMode - Optionally used to set the direction of the y-axis. Use the constants CARTESIAN or JAVASCRIPT. CARTESIAN is used as the default value if this parameter is not supplied.</p>
 <hr />
 <h3 id="noCanvas">noCanvas()</h3>
 <h4>Examples</h4>


### PR DESCRIPTION
The setCanvasSize() function will now have a default of CARTESIAN for
the yAxisMode parameter. The purpose of this change is to make it easier
for new programmers to learn the PyAngelo coordinate system since this
matches the coordinate system they learn in mathematics.