### PR TITLE
Ensure readOnly is set correctly

### DIFF
--- a/resources/assets/js/EditorSetup.js
+++ b/resources/assets/js/EditorSetup.js
@@ -341,6 +341,10 @@ export class Editor {
     this.editor.setReadOnly(readOnly)
   }
 
+  restoreReadOnly () {
+    this.editor.setReadOnly(this.isReadOnly)
+  }
+
   resize () {
     this.editor.resize()
   }

--- a/resources/assets/js/SkulptSetup.js
+++ b/resources/assets/js/SkulptSetup.js
@@ -74,7 +74,7 @@ export function stopSkulpt () {
   _stopExecution = true
   if (receivingInput) {
     hideDebuggingUI()
-    Sk.PyAngelo.aceEditor.setReadOnly(false)
+    Sk.PyAngelo.aceEditor.restoreReadOnly()
     receivingInput = false
     outf('\n')
     logError('Program Stopped!\n')
@@ -365,7 +365,7 @@ export function runSkulpt (code, debugging, stopFunction) {
   skulptRunPromise.finally(function () {
     hideDebuggingUI()
     stopFunction()
-    Sk.PyAngelo.aceEditor.setReadOnly(false)
+    Sk.PyAngelo.aceEditor.restoreReadOnly()
     Sk.PyAngelo.ctx.restore()
   })
 }


### PR DESCRIPTION
After stopping a program the editor was changed to set readOnly to
false. This should instead restore the original readOnly value for the
sketch.