### PR TITLE
Change sketch primary key to be random characters.

### DIFF
--- a/database/migrations/0053_update_sketch_primary_key.sql
+++ b/database/migrations/0053_update_sketch_primary_key.sql
@@ -1,0 +1,20 @@
+alter table lesson drop foreign key lesson_ibfk_2;
+alter table sketch_files drop foreign key sketch_files_ibfk_1;
+alter table tutorial drop foreign key tutorial_ibfk_3;
+
+alter table lesson modify lesson_sketch_id VARCHAR(32) null;
+alter table sketch_files modify sketch_id VARCHAR(32) not null;
+alter table tutorial modify tutorial_sketch_id VARCHAR(32) null;
+
+alter table sketch modify sketch_id VARCHAR(32) not null;
+alter table lesson add foreign key (lesson_sketch_id) references sketch(sketch_id);
+alter table sketch_files add foreign key (sketch_id) references sketch(sketch_id);
+alter table tutorial add foreign key (tutorial_sketch_id) references sketch(sketch_id);
+
+insert into db_change
+values (
+  53,
+  'Add a slug column to the sketch table.',
+  '0053_add_slug_column_to_sketch_table.sql',
+  now()
+);

--- a/public/index.php
+++ b/public/index.php
@@ -23,6 +23,7 @@ if (isset($match['params'])) {
 }
 
 if (!$match) {
+  $match = [];
   $match['target'] = 'PageNotFoundController';
 }
 

--- a/src/PyAngelo/Auth/Auth.php
+++ b/src/PyAngelo/Auth/Auth.php
@@ -71,7 +71,7 @@ class Auth {
       $crsfToken = $_SESSION['crsfToken'];
     }
     else {
-      $crsfToken = bin2hex(openssl_random_pseudo_bytes(32));
+      $crsfToken = bin2hex(random_bytes(32));
       $_SESSION['crsfToken'] = $crsfToken;
     }
     return $crsfToken;

--- a/src/PyAngelo/Controllers/LoginValidateController.php
+++ b/src/PyAngelo/Controllers/LoginValidateController.php
@@ -110,8 +110,8 @@ class LoginValidateController extends Controller {
   private function setRememberMeCookies() {
     if ($this->request->post['rememberme'] == 'y') {
       $personId = $this->auth->person()['person_id'];
-      $session = bin2hex(openssl_random_pseudo_bytes(32));
-      $token = bin2hex(openssl_random_pseudo_bytes(32));
+      $session = bin2hex(random_bytes(32));
+      $token = bin2hex(random_bytes(32));
       $tokenHash = password_hash($token, PASSWORD_DEFAULT);
       $this->auth->insertRememberMe($personId, $session, $tokenHash);
       $this->response->setcookie('rememberme', $personId, time()+60*60*24*365, null, null, null, TRUE);

--- a/src/PyAngelo/FormServices/ForgotPasswordFormService.php
+++ b/src/PyAngelo/FormServices/ForgotPasswordFormService.php
@@ -71,6 +71,6 @@ class ForgotPasswordFormService {
   }
 
   private function getToken() {
-    return bin2hex(openssl_random_pseudo_bytes(32));
+    return bin2hex(random_bytes(32));
   }
 }

--- a/src/PyAngelo/FormServices/RegisterFormService.php
+++ b/src/PyAngelo/FormServices/RegisterFormService.php
@@ -86,7 +86,7 @@ class RegisterFormService {
   }
 
   private function sendActivateEmail($personId, $formData) {
-    $token = bin2hex(openssl_random_pseudo_bytes(32));
+    $token = bin2hex(random_bytes(32));
     $result = $this->personRepository->insertMembershipActivate(
       $personId,
       $formData['email'],

--- a/src/PyAngelo/Repositories/MysqlSketchRepository.php
+++ b/src/PyAngelo/Repositories/MysqlSketchRepository.php
@@ -35,7 +35,7 @@ class MysqlSketchRepository implements SketchRepository {
             WHERE  sketch_id = ?
             AND    deleted = FALSE";
     $stmt = $this->dbh->prepare($sql);
-    $stmt->bind_param('i', $sketchId);
+    $stmt->bind_param('s', $sketchId);
     $stmt->execute();
     $result = $stmt->get_result();
     $stmt->close();
@@ -48,7 +48,7 @@ class MysqlSketchRepository implements SketchRepository {
             WHERE  sketch_id = ?
             AND    deleted = TRUE";
     $stmt = $this->dbh->prepare($sql);
-    $stmt->bind_param('i', $sketchId);
+    $stmt->bind_param('s', $sketchId);
     $stmt->execute();
     $result = $stmt->get_result();
     $stmt->close();
@@ -95,7 +95,7 @@ class MysqlSketchRepository implements SketchRepository {
             WHERE  s.sketch_id = ?
             ORDER by file_id";
     $stmt = $this->dbh->prepare($sql);
-    $stmt->bind_param('i', $sketchId);
+    $stmt->bind_param('s', $sketchId);
     $stmt->execute();
     $result = $stmt->get_result();
     $stmt->close();
@@ -103,6 +103,7 @@ class MysqlSketchRepository implements SketchRepository {
   }
 
   public function createNewSketch($personId, $title, $collectionId, $lessonId = NULL, $tutorialId = NULL, $layout = 'cols') {
+    $sketchId = bin2hex(random_bytes(16));
     $sql = "INSERT INTO sketch (
               sketch_id,
               person_id,
@@ -114,10 +115,11 @@ class MysqlSketchRepository implements SketchRepository {
               created_at,
               updated_at
             )
-            VALUES (NULL, ?, ?, ?, ?, ?, ?, now(), now())";
+            VALUES (?, ?, ?, ?, ?, ?, ?, now(), now())";
     $stmt = $this->dbh->prepare($sql);
     $stmt->bind_param(
-      'iiiiss',
+      'siiiiss',
+      $sketchId,
       $personId,
       $collectionId,
       $lessonId,
@@ -126,7 +128,6 @@ class MysqlSketchRepository implements SketchRepository {
       $layout
     );
     $stmt->execute();
-    $sketchId = $this->dbh->insert_id;
     $stmt->close();
 
     $sql = "INSERT INTO sketch_files (
@@ -138,7 +139,7 @@ class MysqlSketchRepository implements SketchRepository {
             )
             VALUES (NULL, ?, 'main.py', now(), now())";
     $stmt = $this->dbh->prepare($sql);
-    $stmt->bind_param('i', $sketchId);
+    $stmt->bind_param('s', $sketchId);
     $stmt->execute();
     $fileId = $this->dbh->insert_id;
     $stmt->close();
@@ -154,7 +155,7 @@ class MysqlSketchRepository implements SketchRepository {
                    lesson_id = NULL
             WHERE  sketch_id = ?";
     $stmt = $this->dbh->prepare($sql);
-    $stmt->bind_param('i', $sketchId);
+    $stmt->bind_param('s', $sketchId);
     $stmt->execute();
     $rowsUpdated = $this->dbh->affected_rows;
     $stmt->close();
@@ -167,7 +168,7 @@ class MysqlSketchRepository implements SketchRepository {
                    deleted_at = NULL
             WHERE   sketch_id = ?";
     $stmt = $this->dbh->prepare($sql);
-    $stmt->bind_param('i', $sketchId);
+    $stmt->bind_param('s', $sketchId);
     $stmt->execute();
     $rowsUpdated = $this->dbh->affected_rows;
     $stmt->close();
@@ -184,7 +185,7 @@ class MysqlSketchRepository implements SketchRepository {
             )
             VALUES (NULL, ?, ?, now(), now())";
     $stmt = $this->dbh->prepare($sql);
-    $stmt->bind_param('is', $sketchId, $filename);
+    $stmt->bind_param('ss', $sketchId, $filename);
     $stmt->execute();
     $fileId = $this->dbh->insert_id;
     $stmt->close();
@@ -198,7 +199,7 @@ class MysqlSketchRepository implements SketchRepository {
             WHERE   sketch_id = ?
             AND     filename = ?";
     $stmt = $this->dbh->prepare($sql);
-    $stmt->bind_param('is', $sketchId, $filename);
+    $stmt->bind_param('ss', $sketchId, $filename);
     $stmt->execute();
     $rowsDeleted = $this->dbh->affected_rows;
     $stmt->close();
@@ -206,6 +207,7 @@ class MysqlSketchRepository implements SketchRepository {
   }
 
   public function forkSketch($sketchId, $personId, $title, $lessonId = NULL, $tutorialId = NULL, $layout = 'cols') {
+    $newSketchId = bin2hex(random_bytes(16));
     $sql = "INSERT INTO sketch (
               sketch_id,
               person_id,
@@ -216,10 +218,11 @@ class MysqlSketchRepository implements SketchRepository {
               created_at,
               updated_at
             )
-            VALUES (NULL, ?, ?, ?, ?, ?, now(), now())";
+            VALUES (?, ?, ?, ?, ?, ?, now(), now())";
     $stmt = $this->dbh->prepare($sql);
     $stmt->bind_param(
-      'iiiss',
+      'siiiss',
+      $newSketchId,
       $personId,
       $lessonId,
       $tutorialId,
@@ -227,7 +230,6 @@ class MysqlSketchRepository implements SketchRepository {
       $layout
     );
     $stmt->execute();
-    $newSketchId = $this->dbh->insert_id;
     $stmt->close();
 
     $sql = "INSERT INTO sketch_files (
@@ -242,7 +244,7 @@ class MysqlSketchRepository implements SketchRepository {
             WHERE  sketch_id = ?
             ORDER BY file_id";
     $stmt = $this->dbh->prepare($sql);
-    $stmt->bind_param('ii', $newSketchId, $sketchId);
+    $stmt->bind_param('ss', $newSketchId, $sketchId);
     $stmt->execute();
     $fileId = $this->dbh->insert_id;
     $stmt->close();
@@ -255,7 +257,7 @@ class MysqlSketchRepository implements SketchRepository {
             SET    title = ?
             WHERE  sketch_id = ?";
     $stmt = $this->dbh->prepare($sql);
-    $stmt->bind_param('si', $title, $sketchId);
+    $stmt->bind_param('ss', $title, $sketchId);
     $stmt->execute();
     $rowsUpdated = $this->dbh->affected_rows;
     $stmt->close();
@@ -267,7 +269,7 @@ class MysqlSketchRepository implements SketchRepository {
             SET    updated_at = now()
             WHERE  sketch_id = ?";
     $stmt = $this->dbh->prepare($sql);
-    $stmt->bind_param('i', $sketchId);
+    $stmt->bind_param('s', $sketchId);
     $stmt->execute();
     $rowsUpdated = $this->dbh->affected_rows;
     $stmt->close();
@@ -280,7 +282,7 @@ class MysqlSketchRepository implements SketchRepository {
                    updated_at = now()
             WHERE  sketch_id = ?";
     $stmt = $this->dbh->prepare($sql);
-    $stmt->bind_param('si', $layout, $sketchId);
+    $stmt->bind_param('ss', $layout, $sketchId);
     $stmt->execute();
     $rowsUpdated = $this->dbh->affected_rows;
     $stmt->close();
@@ -327,7 +329,7 @@ class MysqlSketchRepository implements SketchRepository {
                    updated_at = now()
             WHERE  sketch_id = ?";
     $stmt = $this->dbh->prepare($sql);
-    $stmt->bind_param('ii', $collectionId, $sketchId);
+    $stmt->bind_param('is', $collectionId, $sketchId);
     $stmt->execute();
     $rowsUpdated = $this->dbh->affected_rows;
     $stmt->close();
@@ -340,7 +342,7 @@ class MysqlSketchRepository implements SketchRepository {
                    updated_at = now()
             WHERE  sketch_id = ?";
     $stmt = $this->dbh->prepare($sql);
-    $stmt->bind_param('i', $sketchId);
+    $stmt->bind_param('s', $sketchId);
     $stmt->execute();
     $rowsUpdated = $this->dbh->affected_rows;
     $stmt->close();

--- a/tests/src/PyAngelo/Controllers/Sketch/SketchAddFileControllerTest.php
+++ b/tests/src/PyAngelo/Controllers/Sketch/SketchAddFileControllerTest.php
@@ -74,7 +74,7 @@ class SketchAddFileControllerTest extends TestCase {
   }
 
   public function testWhenNoFilename() {
-    $sketchId = 101;
+    $sketchId = bin2hex(random_bytes(16));
     $this->request->post = ['sketchId' => $sketchId];
     $this->auth->shouldReceive('loggedIn')->once()->with()->andReturn(true);
     $this->auth->shouldReceive('crsfTokenIsValid')->once()->with()->andReturn(true);
@@ -89,7 +89,7 @@ class SketchAddFileControllerTest extends TestCase {
   }
 
   public function testSketchNotInDatabase() {
-    $sketchId = 101;
+    $sketchId = bin2hex(random_bytes(16));
     $filename = 'main.py';
     $this->request->post = [
       'sketchId' => $sketchId,
@@ -112,7 +112,7 @@ class SketchAddFileControllerTest extends TestCase {
   public function testSketchNotOwner() {
     $ownerId = 101;
     $personId = 102;
-    $sketchId = 10;
+    $sketchId = bin2hex(random_bytes(16));
     $filename = 'main.py';
     $sketch = ['sketch_id' => $sketchId, 'person_id' => $ownerId];
     $this->request->post = [
@@ -137,7 +137,7 @@ class SketchAddFileControllerTest extends TestCase {
   public function testSuccess() {
     $ownerId = 101;
     $personId = $ownerId;
-    $sketchId = 220;
+    $sketchId = bin2hex(random_bytes(16));
     $fileId = 1000;
     $filename = 'main.py';
     $sketch = [

--- a/tests/src/PyAngelo/Controllers/Sketch/SketchCanvasOnlyControllerTest.php
+++ b/tests/src/PyAngelo/Controllers/Sketch/SketchCanvasOnlyControllerTest.php
@@ -38,7 +38,7 @@ class SketchCanvasOnlyControllerTest extends TestCase {
   }
 
   public function testRedirectToPageNotFoundWhenSlugNotInDatabase() {
-    $sketchId = 101;
+    $sketchId = bin2hex(random_bytes(16));
     $this->request->get['sketchId'] = $sketchId;
     $this->sketchRepository->shouldReceive('getSketchById')->once()->with($sketchId)->andReturn(NULL);
 
@@ -49,7 +49,7 @@ class SketchCanvasOnlyControllerTest extends TestCase {
   }
 
   public function testWhenValidSketch() {
-    $sketchId = 0;
+    $sketchId = bin2hex(random_bytes(16));
 
     $sketch = [
       'sketch_id' => $sketchId,

--- a/tests/src/PyAngelo/Controllers/Sketch/SketchDeleteControllerTest.php
+++ b/tests/src/PyAngelo/Controllers/Sketch/SketchDeleteControllerTest.php
@@ -39,7 +39,7 @@ class SketchDeleteControllerTest extends TestCase {
 
   public function testSketchDeleteControllerWhenNotLoggedIn() {
     $this->auth->shouldReceive('loggedIn')->once()->with()->andReturn(false);
-    $sketchId = 999;
+    $sketchId = bin2hex(random_bytes(16));
     $this->request->post["sketchId"] = $sketchId;
     $response = $this->controller->exec();
     $responseVars = $response->getVars();
@@ -52,7 +52,7 @@ class SketchDeleteControllerTest extends TestCase {
   public function testSketchDeleteControllerWhenInvalidCrsfToken() {
     $this->auth->shouldReceive('loggedIn')->once()->with()->andReturn(true);
     $this->auth->shouldReceive('crsfTokenIsValid')->once()->with()->andReturn(false);
-    $sketchId = 999;
+    $sketchId = bin2hex(random_bytes(16));
     $this->request->post["sketchId"] = $sketchId;
     $response = $this->controller->exec();
     $responseVars = $response->getVars();
@@ -63,7 +63,7 @@ class SketchDeleteControllerTest extends TestCase {
   }
 
   public function testSketchDeleteControllerWhenNotValidSketch() {
-    $sketchId = 999;
+    $sketchId = bin2hex(random_bytes(16));
     $this->request->post["sketchId"] = $sketchId;
     $this->auth->shouldReceive('loggedIn')->once()->with()->andReturn(true);
     $this->auth->shouldReceive('crsfTokenIsValid')->once()->with()->andReturn(true);
@@ -79,7 +79,7 @@ class SketchDeleteControllerTest extends TestCase {
   public function testSketchDeleteControllerWhenNotOwnerOfSketch() {
     $personId = 88;
     $sketchPersonId = 92;
-    $sketchId = 999;
+    $sketchId = bin2hex(random_bytes(16));
     $this->request->post["sketchId"] = $sketchId;
     $sketch = [
       'sketch' => $sketchId,
@@ -100,7 +100,7 @@ class SketchDeleteControllerTest extends TestCase {
   public function testSketchDeleteControllerWhenCannotDelete() {
     $personId = 88;
     $sketchPersonId = 88;
-    $sketchId = 999;
+    $sketchId = bin2hex(random_bytes(16));
     $this->request->post["sketchId"] = $sketchId;
     $sketch = [
       'sketch' => $sketchId,
@@ -122,7 +122,7 @@ class SketchDeleteControllerTest extends TestCase {
   public function testSketchDeleteControllerSuccess() {
     $personId = 88;
     $sketchPersonId = 88;
-    $sketchId = 999;
+    $sketchId = bin2hex(random_bytes(16));
     $this->request->post["sketchId"] = $sketchId;
     $sketch = [
       'sketch' => $sketchId,

--- a/tests/src/PyAngelo/Controllers/Sketch/SketchDeleteFileControllerTest.php
+++ b/tests/src/PyAngelo/Controllers/Sketch/SketchDeleteFileControllerTest.php
@@ -74,7 +74,7 @@ class SketchDeleteFileControllerTest extends TestCase {
   }
 
   public function testWhenNoFilename() {
-    $sketchId = 101;
+    $sketchId = bin2hex(random_bytes(16));
     $this->request->post = ['sketchId' => $sketchId];
     $this->auth->shouldReceive('loggedIn')->once()->with()->andReturn(true);
     $this->auth->shouldReceive('crsfTokenIsValid')->once()->with()->andReturn(true);
@@ -89,7 +89,7 @@ class SketchDeleteFileControllerTest extends TestCase {
   }
 
   public function testSketchNotInDatabase() {
-    $sketchId = 101;
+    $sketchId = bin2hex(random_bytes(16));
     $filename = 'main.py';
     $this->request->post = [
       'sketchId' => $sketchId,
@@ -112,7 +112,7 @@ class SketchDeleteFileControllerTest extends TestCase {
   public function testSketchNotOwner() {
     $ownerId = 101;
     $personId = 102;
-    $sketchId = 10;
+    $sketchId = bin2hex(random_bytes(16));
     $filename = 'main.py';
     $sketch = ['sketch_id' => $sketchId, 'person_id' => $ownerId];
     $this->request->post = [
@@ -137,7 +137,7 @@ class SketchDeleteFileControllerTest extends TestCase {
   public function testAttemptDeleteMain() {
     $personId = 101;
     $ownerId = 101;
-    $sketchId = 101;
+    $sketchId = bin2hex(random_bytes(16));
     $filename = 'main.py';
     $this->request->post = [
       'sketchId' => $sketchId,
@@ -166,7 +166,7 @@ class SketchDeleteFileControllerTest extends TestCase {
   public function testFileDoesNotExist() {
     $ownerId = 101;
     $personId = $ownerId;
-    $sketchId = 10;
+    $sketchId = bin2hex(random_bytes(16));
     $filename = 'randomFile.py';
     $this->request->post = [
       'sketchId' => $sketchId,
@@ -196,7 +196,7 @@ class SketchDeleteFileControllerTest extends TestCase {
   public function testSuccess() {
     $ownerId = 101;
     $personId = $ownerId;
-    $sketchId = 220;
+    $sketchId = bin2hex(random_bytes(16));
     $fileId = 1000;
     $filename = 'randomFile.py';
     $sketch = [

--- a/tests/src/PyAngelo/Controllers/Sketch/SketchForkControllerTest.php
+++ b/tests/src/PyAngelo/Controllers/Sketch/SketchForkControllerTest.php
@@ -65,7 +65,7 @@ class SketchForkControllerTest extends TestCase {
   }
 
   public function testRedirectsToHomePageWhenSketchNotInDatabase() {
-    $anySketchId = 101;
+    $anySketchId = bin2hex(random_bytes(16));
     $this->request->post['sketchId'] = $anySketchId;
 
     $this->auth->shouldReceive('loggedIn')->once()->with()->andReturn(true);

--- a/tests/src/PyAngelo/Controllers/Sketch/SketchGetCodeControllerTest.php
+++ b/tests/src/PyAngelo/Controllers/Sketch/SketchGetCodeControllerTest.php
@@ -42,7 +42,7 @@ class SketchGetCodeControllerTest extends TestCase {
   }
 
   public function testSketchNotInDatabase() {
-    $sketchId = 101;
+    $sketchId = bin2hex(random_bytes(16));
     $program = 'canvas.background()';
     $this->request->get['sketchId'] = $sketchId;
     $this->sketchRepository->shouldReceive('getSketchFiles')->once()->with($sketchId)->andReturn();
@@ -76,7 +76,7 @@ class SketchGetCodeControllerTest extends TestCase {
         'filename' => 'main.py'
       ]
     ];
-    $sketchId = 101;
+    $sketchId = bin2hex(random_bytes(16));
     $program = 'canvas.background()';
     $this->request->get['sketchId'] = $sketchId;
     $this->sketchRepository->shouldReceive('getSketchFiles')->once()->with($sketchId)->andReturn($sketchFiles);

--- a/tests/src/PyAngelo/Controllers/Sketch/SketchRenameControllerTest.php
+++ b/tests/src/PyAngelo/Controllers/Sketch/SketchRenameControllerTest.php
@@ -70,7 +70,7 @@ class SketchRenameControllerTest extends TestCase {
   }
 
   public function testWhenNoTitle() {
-    $sketchId = 101;
+    $sketchId = bin2hex(random_bytes(16));
     $this->request->post = ['sketchId' => $sketchId];
     $this->auth->shouldReceive('loggedIn')->once()->with()->andReturn(true);
     $this->auth->shouldReceive('crsfTokenIsValid')->once()->with()->andReturn(true);
@@ -86,7 +86,7 @@ class SketchRenameControllerTest extends TestCase {
   }
 
   public function testWhenTitleOnlyWhitespace() {
-    $sketchId = 101;
+    $sketchId = bin2hex(random_bytes(16));
     $this->request->post = [
       'sketchId' => $sketchId,
       'newTitle' => '   '
@@ -105,7 +105,7 @@ class SketchRenameControllerTest extends TestCase {
   }
 
   public function testSketchNotInDatabase() {
-    $sketchId = 101;
+    $sketchId = bin2hex(random_bytes(16));
     $this->request->post = [
       'sketchId' => $sketchId,
       'newTitle' => 'great-sketch'
@@ -127,7 +127,7 @@ class SketchRenameControllerTest extends TestCase {
   public function testSketchNotOwner() {
     $ownerId = 101;
     $personId = 102;
-    $sketchId = 10;
+    $sketchId = bin2hex(random_bytes(16));
     $sketch = ['sketch_id' => $sketchId, 'person_id' => $ownerId];
     $this->request->post = [
       'sketchId' => $sketchId,
@@ -151,7 +151,7 @@ class SketchRenameControllerTest extends TestCase {
   public function testRenameSuccess() {
     $ownerId = 101;
     $personId = $ownerId;
-    $sketchId = 220;
+    $sketchId = bin2hex(random_bytes(16));
     $fileId = 1000;
     $newTitle = 'new-title';
     $sketch = [

--- a/tests/src/PyAngelo/Controllers/Sketch/SketchRestoreControllerTest.php
+++ b/tests/src/PyAngelo/Controllers/Sketch/SketchRestoreControllerTest.php
@@ -39,7 +39,7 @@ class SketchRestoreControllerTest extends TestCase {
 
   public function testSketchRestoreControllerWhenNotLoggedIn() {
     $this->auth->shouldReceive('loggedIn')->once()->with()->andReturn(false);
-    $sketchId = 999;
+    $sketchId = bin2hex(random_bytes(16));
     $this->request->post["sketchId"] = $sketchId;
     $response = $this->controller->exec();
     $responseVars = $response->getVars();
@@ -52,7 +52,7 @@ class SketchRestoreControllerTest extends TestCase {
   public function testSketchRestoreControllerWhenInvalidCrsfToken() {
     $this->auth->shouldReceive('loggedIn')->once()->with()->andReturn(true);
     $this->auth->shouldReceive('crsfTokenIsValid')->once()->with()->andReturn(false);
-    $sketchId = 999;
+    $sketchId = bin2hex(random_bytes(16));
     $this->request->post["sketchId"] = $sketchId;
     $response = $this->controller->exec();
     $responseVars = $response->getVars();
@@ -63,7 +63,7 @@ class SketchRestoreControllerTest extends TestCase {
   }
 
   public function testSketchRestoreControllerWhenNotValidSketch() {
-    $sketchId = 999;
+    $sketchId = bin2hex(random_bytes(16));
     $this->request->post["sketchId"] = $sketchId;
     $this->auth->shouldReceive('loggedIn')->once()->with()->andReturn(true);
     $this->auth->shouldReceive('crsfTokenIsValid')->once()->with()->andReturn(true);
@@ -79,7 +79,7 @@ class SketchRestoreControllerTest extends TestCase {
   public function testSketchRestoreControllerWhenNotOwnerOfSketch() {
     $personId = 88;
     $sketchPersonId = 92;
-    $sketchId = 999;
+    $sketchId = bin2hex(random_bytes(16));
     $this->request->post["sketchId"] = $sketchId;
     $sketch = [
       'sketch' => $sketchId,
@@ -100,7 +100,7 @@ class SketchRestoreControllerTest extends TestCase {
   public function testSketchResstoreControllerWhenCannotDelete() {
     $personId = 88;
     $sketchPersonId = 88;
-    $sketchId = 999;
+    $sketchId = bin2hex(random_bytes(16));
     $this->request->post["sketchId"] = $sketchId;
     $sketch = [
       'sketch' => $sketchId,
@@ -122,7 +122,7 @@ class SketchRestoreControllerTest extends TestCase {
   public function testSketchRestoreControllerSuccess() {
     $personId = 88;
     $sketchPersonId = 88;
-    $sketchId = 999;
+    $sketchId = bin2hex(random_bytes(16));
     $this->request->post["sketchId"] = $sketchId;
     $sketch = [
       'sketch' => $sketchId,

--- a/tests/src/PyAngelo/Controllers/Sketch/SketchSaveControllerTest.php
+++ b/tests/src/PyAngelo/Controllers/Sketch/SketchSaveControllerTest.php
@@ -74,7 +74,7 @@ class SketchSaveControllerTest extends TestCase {
   }
 
   public function testWhenNoFilename() {
-    $sketchId = 101;
+    $sketchId = bin2hex(random_bytes(16));
     $this->request->post = ['sketchId' => $sketchId];
     $this->auth->shouldReceive('loggedIn')->once()->with()->andReturn(true);
     $this->auth->shouldReceive('crsfTokenIsValid')->once()->with()->andReturn(true);
@@ -90,7 +90,7 @@ class SketchSaveControllerTest extends TestCase {
   }
 
   public function testWhenNoProgram() {
-    $sketchId = 101;
+    $sketchId = bin2hex(random_bytes(16));
     $filename = 'main.py';
     $this->request->post = [
       'sketchId' => $sketchId,
@@ -110,7 +110,7 @@ class SketchSaveControllerTest extends TestCase {
   }
 
   public function testSketchNotInDatabase() {
-    $sketchId = 101;
+    $sketchId = bin2hex(random_bytes(16));
     $filename = 'main.py';
     $program = 'canvas.background()';
     $this->request->post = [
@@ -135,7 +135,7 @@ class SketchSaveControllerTest extends TestCase {
   public function testSketchNotOwner() {
     $ownerId = 101;
     $personId = 102;
-    $sketchId = 10;
+    $sketchId = bin2hex(random_bytes(16));
     $filename = 'main.py';
     $sketch = ['sketch_id' => $sketchId, 'person_id' => $ownerId];
     $program = 'canvas.background()';
@@ -162,7 +162,7 @@ class SketchSaveControllerTest extends TestCase {
   public function testSuccess() {
     $ownerId = 101;
     $personId = $ownerId;
-    $sketchId = 220;
+    $sketchId = bin2hex(random_bytes(16));
     $fileId = 1000;
     $filename = 'main.py';
     $sketch = [

--- a/tests/src/PyAngelo/Controllers/Sketch/SketchShowControllerTest.php
+++ b/tests/src/PyAngelo/Controllers/Sketch/SketchShowControllerTest.php
@@ -38,7 +38,7 @@ class SketchShowControllerTest extends TestCase {
   }
 
   public function testRedirectToPageNotFoundWhenSlugNotInDatabase() {
-    $sketchId = 101;
+    $sketchId = bin2hex(random_bytes(16));
     $this->request->get['sketchId'] = $sketchId;
     $this->sketchRepository->shouldReceive('getSketchById')->once()->with($sketchId)->andReturn(NULL);
 
@@ -49,7 +49,7 @@ class SketchShowControllerTest extends TestCase {
   }
 
   public function testWhenValidSketch() {
-    $sketchId = 0;
+    $sketchId = bin2hex(random_bytes(16));
 
     $sketch = [
       'sketch_id' => $sketchId,

--- a/tests/src/PyAngelo/Controllers/Sketch/SketchUpdateLayoutControllerTest.php
+++ b/tests/src/PyAngelo/Controllers/Sketch/SketchUpdateLayoutControllerTest.php
@@ -72,7 +72,7 @@ class SketchUpdateLayoutControllerTest extends TestCase {
   }
 
   public function testWhenNoLayout() {
-    $sketchId = 101;
+    $sketchId = bin2hex(random_bytes(16));
     $this->request->post = [
       'sketchId' => $sketchId
     ];
@@ -90,7 +90,7 @@ class SketchUpdateLayoutControllerTest extends TestCase {
   }
 
   public function testSketchNotInDatabase() {
-    $sketchId = 101;
+    $sketchId = bin2hex(random_bytes(16));
     $layout = 'cols';
     $this->request->post = [
       'sketchId' => $sketchId,
@@ -113,7 +113,7 @@ class SketchUpdateLayoutControllerTest extends TestCase {
   public function testSketchNotOwner() {
     $ownerId = 101;
     $personId = 102;
-    $sketchId = 10;
+    $sketchId = bin2hex(random_bytes(16));
     $layout = 'cols';
     $sketch = ['sketch_id' => $sketchId, 'person_id' => $ownerId];
     $this->request->post = [
@@ -138,7 +138,7 @@ class SketchUpdateLayoutControllerTest extends TestCase {
   public function testSuccess() {
     $ownerId = 101;
     $personId = $ownerId;
-    $sketchId = 220;
+    $sketchId = bin2hex(random_bytes(16));
     $fileId = 1000;
     $layout = 'cols';
     $sketch = [

--- a/views/reference/versions-menu.html.php
+++ b/views/reference/versions-menu.html.php
@@ -1,6 +1,10 @@
       <div class="col-md-3">
         <h2>Versions</h2>
         <ul>
+          <li><a href="#version2.1">Version 2.1</a></li>
+          <ul>
+            <li><a href="#minor2.1">minor changes</a></li>
+          </ul>
           <li><a href="#version2.0">Version 2.0</a></li>
           <ul>
             <li><a href="#breaking2.0">breaking changes</a></li>

--- a/views/reference/versions.html.php
+++ b/views/reference/versions.html.php
@@ -9,6 +9,12 @@ include __DIR__ . DIRECTORY_SEPARATOR . '../layout/navbar.html.php';
       ?>
       <div class="col-md-9">
         <h1>PyAngelo Versions</h1>
+        <h2 id="version2.1">Version 2.1</h2>
+        <h3 id="minor2.1">2.1 Minor Changes</h3>
+        <ul>
+          <li>Sketch Ids are now randomly generated</li>
+        </ul>
+        <hr />
         <h2 id="version2.0">Version 2.0</h2>
         <p>The defaut value for the yAxisMode parameter for the setCanvasSize() function was changed from JAVASCRIPT to CARTESIAN. The effect of this is that the bottom left corner of the canvas will by default be located at (0, 0).</p>
         <div class="well">


### PR DESCRIPTION
Students were creating their own sketches and then looking at the sketch
numbers below theirs to see if they could copy work from other students.
This change will make it harder to find other sketches. Of course each
sketch can still be shared with the varchar sketch id.