### PR TITLE
Fix apache error originating from Auth.php

### DIFF
--- a/src/PyAngelo/Auth/Auth.php
+++ b/src/PyAngelo/Auth/Auth.php
@@ -136,12 +136,11 @@ class Auth {
 
   private function authenticateRememberMeCookie($personId, $sessionId, $token) {
     $rememberMeCookie = $this->personRepository->getRememberMe($personId, $sessionId);
-    if (password_verify($token, $rememberMeCookie['token'])) {
-      return TRUE;
-    }
-    else {
+    if (is_null($rememberMeCookie))
       return FALSE;
-    }
+    if (password_verify($token, $rememberMeCookie['token']))
+      return TRUE;
+    return FALSE;
   }
 
   public function authenticateLogin($loginEmail, $loginPassword) {


### PR DESCRIPTION
The code queries the database to see if there is a remember me token but
if this does not exist or has expired it returns null.