### PR TITLE
Show past subscriptions with a canceled status

### DIFF
--- a/src/PyAngelo/Repositories/MysqlStripeRepository.php
+++ b/src/PyAngelo/Repositories/MysqlStripeRepository.php
@@ -406,7 +406,7 @@ class MysqlStripeRepository implements StripeRepository {
             JOIN   stripe_product sprod on sprod.stripe_product_id = sp.stripe_product_id
             JOIN   currency c on sp.currency_code = c.currency_code
             WHERE  ss.person_id = ?
-            AND    ss.status not in ('active', 'past_due')
+            AND    ss.status = 'canceled'
             ORDER BY ss.start_date DESC";
     $stmt = $this->dbh->prepare($sql);
     $stmt->bind_param('i', $personId);


### PR DESCRIPTION
If the user visits their subscription page we should only show
subscriptions as past if they are in the canceled status and not a
status like incomplete or incomplete_expired.