### PR TITLE
Fix error with debugger.

### DIFF
--- a/resources/assets/js/SkulptSetup.js
+++ b/resources/assets/js/SkulptSetup.js
@@ -157,6 +157,9 @@ export function runSkulpt (code, debugging, stopFunction) {
           child = child.child
         }
       }
+      while (child.$lineno === undefined) {
+        child = child.child
+      }
       if (currentLineNo === child.$lineno) {
         return Promise.resolve(susp.resume())
       }


### PR DESCRIPTION
Something has changed with Skulpt and it seems there is an extra
suspension sometimes before getting to the child element which contains
the Python filename and line no.